### PR TITLE
Add site-effect correction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           environments: test
           frozen: true
       - run: pixi run unittest
-      - run: pixi run smoketestlight
+      - run: pixi run smoketestlight --cov-append
       - uses: codecov/codecov-action@v6
         if: ${{ always() }}
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,13 @@ repos:
     rev: v1.19.1
     hooks:
     -   id: mypy
-        additional_dependencies: [pandas-stubs, types-tqdm, types-setuptools, types-Jinja2, textual]
+        additional_dependencies:
+        -   pandas-stubs
+        -   pytest
+        -   types-tqdm
+        -   types-setuptools
+        -   types-Jinja2
+        -   textual
         args: [--config-file=pyproject.toml]
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.4.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v1.19.1
     hooks:
     -   id: mypy
-        additional_dependencies: [pandas-stubs, types-tqdm, types-setuptools, types-Jinja2]
+        additional_dependencies: [pandas-stubs, types-tqdm, types-setuptools, types-Jinja2, textual]
         args: [--config-file=pyproject.toml]
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.4.2

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,13 +14,16 @@
 #         # noisy red coverage status on github PRs.
 #         target: auto
 #         threshold: 1%
-comment:                  # this is a top-level key
+comment: # this is a top-level key
   layout: reach, diff, flags, files
   behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: no        # [yes :: must have a base report to post]
-  require_head: yes       # [yes :: must have a head report to post]
+  require_changes: false # if true: only post the comment if coverage changes
+  require_base: false # if true: must have a base report to post
+  require_head: false # if true: must have a head report to post
 
 ignore:
-- '*/tests/'    # ignore folders related to testing
-- '*/data/'
+  - "**/tests/**"
+  - "**/test_*.py"
+  - "**/conftest.py"
+  - "**/data/**"
+  - "**/setup.py"

--- a/data/halfpipe/participants.tsv
+++ b/data/halfpipe/participants.tsv
@@ -1,1 +1,1 @@
-../../.git/annex/objects/gG/5m/MD5E-s16387--b0d7908c25384a3ecd7c317238748596.tsv/MD5E-s16387--b0d7908c25384a3ecd7c317238748596.tsv
+../../.git/annex/objects/Fj/K7/MD5E-s16372--3c23f937d8662e3bbd2f588f3d992e8b.tsv/MD5E-s16372--3c23f937d8662e3bbd2f588f3d992e8b.tsv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,13 +164,18 @@ warn_unused_ignores = true
 ignore_missing_imports = true
 module = [
   "bids.*",
+  "brainspace.*",
   "datalad.*",
+  "joblib",
   "matplotlib.*",
+  "nilearn",
+  "nilearn.*",
   "numba.*",
   "patsy.*",
   "rich.*",
   "scipy.*",
   "seaborn.*",
+  "sklearn.*",
   "statsmodels.*",
   "templateflow.*",
   "nibabel.*",

--- a/wonkyconn/atlas.py
+++ b/wonkyconn/atlas.py
@@ -142,7 +142,8 @@ class DsegAtlas(Atlas):
         for n in network_labels:
             cur_region = math_img(f"img=={n}", img=yeo7_nii)
             masker = NiftiMasker(cur_region)
-            atlas_parcel_in_network = masker.fit_transform(self.image)
+            masker.fit()
+            atlas_parcel_in_network = masker.transform(self.image)
             atlas_parcel_in_network = np.unique(atlas_parcel_in_network)[1:]
             region_membership.loc[atlas_parcel_in_network, f"yeo7-{int(n)}"] = 1
         return region_membership

--- a/wonkyconn/atlas.py
+++ b/wonkyconn/atlas.py
@@ -7,8 +7,8 @@ import nibabel as nib
 import numpy as np
 import pandas as pd
 import scipy
-from nilearn.image import iter_img, load_img, math_img, resample_to_img  # type: ignore[import-not-found]
-from nilearn.maskers import NiftiLabelsMasker, NiftiMasker  # type: ignore[import-not-found]
+from nilearn.image import iter_img, load_img, math_img, resample_to_img
+from nilearn.maskers import NiftiLabelsMasker, NiftiMasker
 from numpy import typing as npt
 
 from .logger import logger
@@ -29,7 +29,7 @@ class Atlas(ABC):
     """
 
     seg: str
-    image: nib.nifti1.Nifti1Image
+    image: nib.nifti1.Nifti1Image  # pyright: ignore[reportAttributeAccessIssue]
 
     structure: npt.NDArray[np.bool_] = field(default_factory=lambda: np.ones((3, 3, 3), dtype=bool))
 
@@ -51,7 +51,7 @@ class Atlas(ABC):
             npt.NDArray[np.float64]: An array of centroid coordinates.
         """
         centroid_points = self.get_centroid_points()
-        centroid_coordinates = nib.affines.apply_affine(self.image.affine, centroid_points)
+        centroid_coordinates = nib.affines.apply_affine(self.image.affine, centroid_points)  # pyright: ignore[reportAttributeAccessIssue]
         return centroid_coordinates
 
     def get_distance_matrix(self) -> npt.NDArray[np.float64]:
@@ -65,7 +65,7 @@ class Atlas(ABC):
         centroids = self.get_centroids()
         return scipy.spatial.distance.squareform(scipy.spatial.distance.pdist(centroids))
 
-    def load_yeo7_network(self) -> nib.nifti1.Nifti1Image:
+    def load_yeo7_network(self) -> nib.nifti1.Nifti1Image:  # pyright: ignore[reportAttributeAccessIssue]
         """
         Load and resample the yeo 7 networks to the atlas's space.
 
@@ -102,10 +102,10 @@ class Atlas(ABC):
             None
 
         """
-        image = nib.nifti1.load(path)
+        image = nib.nifti1.load(path)  # pyright: ignore[reportAttributeAccessIssue]
 
         if image.ndim <= 3 or image.shape[3] == 1:
-            return DsegAtlas(seg, nib.funcs.squeeze_image(image))
+            return DsegAtlas(seg, nib.funcs.squeeze_image(image))  # pyright: ignore[reportAttributeAccessIssue]
         else:
             return ProbsegAtlas(seg, image)
 
@@ -161,7 +161,7 @@ class ProbsegAtlas(Atlas):
 
     def get_centroid_points(self) -> npt.NDArray[np.float64]:
         return np.asarray(
-            [self._get_centroid_point(i, image.get_fdata()) for i, image in enumerate(nib.funcs.four_to_three(self.image))]
+            [self._get_centroid_point(i, image.get_fdata()) for i, image in enumerate(nib.funcs.four_to_three(self.image))]  # pyright: ignore[reportAttributeAccessIssue]
         )
 
     def get_yeo7_membership(self) -> pd.DataFrame:

--- a/wonkyconn/config.py
+++ b/wonkyconn/config.py
@@ -27,6 +27,7 @@ class WonkyConnConfig:
     light_mode: bool = False
     theme: str | None = None  # GUI-only
     suppress_warnings: bool = False
+    site_correction: bool = False
 
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace | None) -> "WonkyConnConfig":
@@ -52,6 +53,7 @@ class WonkyConnConfig:
             debug=bool(getattr(args, "debug", False)),
             light_mode=bool(getattr(args, "light_mode", False)),
             suppress_warnings=bool(getattr(args, "suppress_warnings", False)),
+            site_correction=bool(getattr(args, "site_correction", False)),
         )
 
     def to_namespace(self) -> argparse.Namespace:
@@ -75,4 +77,5 @@ class WonkyConnConfig:
             verbosity=self.verbosity,
             debug=self.debug,
             light_mode=self.light_mode,
+            site_correction=self.site_correction,
         )

--- a/wonkyconn/config.py
+++ b/wonkyconn/config.py
@@ -14,7 +14,7 @@ def _coerce_path(value: str | Path | None) -> Path | None:
 
 
 @dataclass
-class WonkyConnConfig:
+class WonkyconnConfig:
     """Shared configuration for CLI and GUI."""
 
     bids_dir: Path | None = None
@@ -30,7 +30,7 @@ class WonkyConnConfig:
     site_correction: bool = False
 
     @classmethod
-    def from_cli_args(cls, args: argparse.Namespace | None) -> "WonkyConnConfig":
+    def from_cli_args(cls, args: argparse.Namespace | None) -> "WonkyconnConfig":
         """Create a config from argparse args (may be partial when GUI is requested)."""
         if args is None:
             return cls()
@@ -40,20 +40,20 @@ class WonkyConnConfig:
             verbosity = verbosity[0]
 
         atlas_entries: list[tuple[str, Path]] = list()
-        for label, atlas_path in getattr(args, "atlas", []) or []:
+        for label, atlas_path in args.atlas or []:
             atlas_entries.append((label, Path(atlas_path).expanduser().resolve()))
 
         return cls(
-            bids_dir=_coerce_path(getattr(args, "bids_dir", None)),
-            output_dir=_coerce_path(getattr(args, "output_dir", None)),
-            analysis_level=getattr(args, "analysis_level", "group"),
-            phenotypes=_coerce_path(getattr(args, "phenotypes", None)),
+            bids_dir=_coerce_path(args.bids_dir),
+            output_dir=_coerce_path(args.output_dir),
+            analysis_level=args.analysis_level,
+            phenotypes=_coerce_path(args.phenotypes),
             atlas=atlas_entries,
             verbosity=int(verbosity) if verbosity is not None else 2,
-            debug=bool(getattr(args, "debug", False)),
-            light_mode=bool(getattr(args, "light_mode", False)),
-            suppress_warnings=bool(getattr(args, "suppress_warnings", False)),
-            site_correction=bool(getattr(args, "site_correction", False)),
+            debug=bool(args.debug),
+            light_mode=bool(args.light_mode),
+            suppress_warnings=bool(args.suppress_warnings),
+            site_correction=bool(args.site_correction),
         )
 
     def to_namespace(self) -> argparse.Namespace:

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -44,15 +44,10 @@ def regress_site(
 
     design_test = np.column_stack([np.ones(len(test_site)), test_site.to_numpy()])
 
-    beta, *_ = np.linalg.lstsq(
-        design_train,
-        X_train,
-        rcond=None,
-    )
-
-    beta_site = beta[1:, :]
-    X_train_corr = X_train - design_train[:, 1:] @ beta_site
-    X_test_corr = X_test - design_test[:, 1:] @ beta_site
+    beta_train, *_ = np.linalg.lstsq(design_train, X_train, rcond=None,)
+    beta_test, *_ = np.linalg.lstsq(design_test, X_test, rcond=None,)
+    X_train_corr = X_train - design_train[:, 1:] @ beta_train[1:, :]
+    X_test_corr = X_test - design_test[:, 1:] @ beta_test[1:, :]
 
     return X_train_corr, X_test_corr
 
@@ -88,7 +83,7 @@ def training_pipeline(
         y = LabelEncoder().fit_transform(target_labels)
         estimator = LogisticRegression(max_iter=5000, solver="saga", penalty="l2", n_jobs=n_jobs, random_state=random_state)
         cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
-        scoring_metrics = {"accuracy": "accuracy", "roc_auc": "roc_auc"}
+        scoring_metrics = ["accuracy", "roc_auc"]
         splits = cv_strategy.split(connectivity_data, y)
 
     else:
@@ -99,7 +94,7 @@ def training_pipeline(
         cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
         splits = list(cv_strategy.split(np.zeros_like(bins), bins))
 
-        scoring_metrics = {"mae": "neg_mean_absolute_error", "r2": "r2"}
+        scoring_metrics = ["mae", "r2"]
 
     pipe = Pipeline(
         [

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -4,16 +4,16 @@ from typing import TYPE_CHECKING, Dict, List
 
 import numpy as np
 import pandas as pd
-from joblib import parallel_backend  # type: ignore[import-not-found]
-from nilearn.connectome import sym_matrix_to_vec  # type: ignore[import-not-found]
+from joblib import parallel_backend
+from nilearn.connectome import sym_matrix_to_vec
 from numpy.typing import NDArray
-from sklearn.base import BaseEstimator, TransformerMixin  # type: ignore[import-not-found]
-from sklearn.decomposition import PCA  # type: ignore[import-not-found]
-from sklearn.impute import SimpleImputer  # type: ignore[import-not-found]
-from sklearn.linear_model import LogisticRegression, Ridge  # type: ignore[import-not-found]
-from sklearn.model_selection import StratifiedShuffleSplit, cross_validate  # type: ignore[import-not-found]
-from sklearn.pipeline import Pipeline  # type: ignore[import-not-found]
-from sklearn.preprocessing import LabelEncoder, StandardScaler  # type: ignore[import-not-found]
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.decomposition import PCA
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression, Ridge
+from sklearn.model_selection import StratifiedShuffleSplit, cross_validate
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import LabelEncoder, StandardScaler
 
 if TYPE_CHECKING:
     from ..base import ConnectivityMatrix

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List
 
 import numpy as np
@@ -10,7 +11,7 @@ from numpy.typing import NDArray
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.decomposition import PCA
 from sklearn.impute import SimpleImputer
-from sklearn.linear_model import LogisticRegression, Ridge
+from sklearn.linear_model import LinearRegression, LogisticRegression, Ridge
 from sklearn.model_selection import StratifiedShuffleSplit, cross_validate
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import LabelEncoder, StandardScaler
@@ -19,19 +20,25 @@ if TYPE_CHECKING:
     from ..base import ConnectivityMatrix
 
 
+@dataclass
 class SiteRegressor(BaseEstimator, TransformerMixin):
-    """
-    Regress out site effects from connectivity features.
-    """
+    sites: NDArray[np.str_]
 
-    def __init__(self: SiteRegressor, n_connectivity_features: int) -> None:
+    model: LinearRegression = field(default_factory=LinearRegression)
+
+    def _get_dummies(self: SiteRegressor, X: pd.DataFrame) -> pd.DataFrame:  # noqa: N803
         """
+        Convert site labels to dummy variables.
+
         Args:
-            n_connectivity_features: Number of connectivity features in the input data.
-        """
-        self.n_connectivity_features = n_connectivity_features
+            X: A DataFrame containing the site labels.
 
-    def fit(self: SiteRegressor, connectivity_data_site: NDArray[np.float32], y: None = None) -> SiteRegressor:
+        Returns:
+            A DataFrame with dummy variables for each site.
+        """
+        return pd.get_dummies(self.sites[X.index], drop_first=False, dtype=np.float32)
+
+    def fit(self: SiteRegressor, X: pd.DataFrame, y: pd.DataFrame | None = None) -> SiteRegressor:  # noqa: N803
         """
         Fit the site regressor to the connectivity data.
 
@@ -43,18 +50,17 @@ class SiteRegressor(BaseEstimator, TransformerMixin):
         Returns:
             self: Returns the instance itself.
         """
-        connectivity_feat = connectivity_data_site[:, : self.n_connectivity_features]
-        site = connectivity_data_site[:, self.n_connectivity_features :]
+        fit_sites = np.asarray(self.sites[X.index])
+        if np.unique(fit_sites).size < 2:
+            raise ValueError("SiteRegressor requires at least two sites in the training data.")
 
-        # Add intercept
-        design = np.column_stack([np.ones(len(site)), site])
+        y = X
 
         # Estimate coefficients on the training fold only
-        self.beta_ = np.linalg.lstsq(design, connectivity_feat, rcond=None)[0]
-
+        self.model.fit(self._get_dummies(X), y)
         return self
 
-    def transform(self: SiteRegressor, connectivity_data_site: NDArray[np.float32]) -> NDArray[np.float64]:
+    def transform(self: SiteRegressor, X: pd.DataFrame) -> pd.DataFrame:  # noqa: N803
         """
         Transform the connectivity data by regressing out site effects.
         Args:
@@ -64,15 +70,7 @@ class SiteRegressor(BaseEstimator, TransformerMixin):
         Returns:
             A 2D array of connectivity features with site effects regressed out.
         """
-
-        connectivity_feat = connectivity_data_site[:, : self.n_connectivity_features]
-        site = connectivity_data_site[:, self.n_connectivity_features :]
-
-        # Add intercept
-        design = np.column_stack([np.ones(len(site)), site])
-
-        # Remove only the site contribution (keep the intercept)
-        return connectivity_feat - design[:, 1:] @ self.beta_[1:]
+        return X - self.model.predict(self._get_dummies(X))
 
 
 def training_pipeline(
@@ -100,42 +98,37 @@ def training_pipeline(
     Returns:
         pd.DataFrame: Statistics (mean, 95% CI) of the scores obtained.
     """
-    connectivity_data = np.asarray(connectivity_data, dtype=np.float32, order="C")
-
-    # Transform site labels into dummy variables and concatenate with connectivity data
-    if sites is not None:
-        site = pd.get_dummies(
-            sites,
-            drop_first=True,
-            dtype=np.float32,
-        ).to_numpy()
-
-        connectivity_data_site = np.concatenate([connectivity_data, site], axis=1)
-    else:
-        connectivity_data_site = connectivity_data
+    connectivity_data_frame = pd.DataFrame(connectivity_data, dtype=np.float32)
 
     if task_type == "classification":
-        y_train = LabelEncoder().fit_transform(target_labels)
-        estimator = LogisticRegression(max_iter=5000, solver="saga", penalty="l2", n_jobs=n_jobs, random_state=random_state)
-        cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
+        y_train = pd.Series(LabelEncoder().fit_transform(target_labels))  # pyright: ignore[reportArgumentType, reportCallIssue]
+        estimator = LogisticRegression(max_iter=5000, solver="saga", l1_ratio=0.0, random_state=random_state)
+
+        bins = y_train
+
         scoring_metrics = {"accuracy": "accuracy", "roc_auc": "roc_auc"}
     else:
-        y_train = np.asarray(target_labels)
+        y_train = pd.Series(target_labels)
         estimator = Ridge(alpha=1.0)
 
         bins = pd.qcut(y_train, q=5, labels=False, duplicates="drop")
-        cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
-        splits = list(cv_strategy.split(np.zeros_like(bins), bins))
-        cv_strategy = splits
 
         scoring_metrics = {"mae": "neg_mean_absolute_error", "r2": "r2"}
 
-    steps = [
-        ("imputer", SimpleImputer(strategy="median")),
+    if sites is not None:
+        data_frame = pd.DataFrame({"site": sites, "bins": bins})
+        # Get unique row indices as combined bins
+        bins = data_frame.groupby(data_frame.columns.tolist(), sort=False).ngroup()
+
+    cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
+    splits = list(cv_strategy.split(np.zeros(len(bins)), bins))
+
+    steps: list[tuple[str, BaseEstimator]] = [
+        ("imputer", SimpleImputer(strategy="median").set_output(transform="pandas")),
     ]
 
     if sites is not None:
-        steps.append(("site_regression", SiteRegressor(connectivity_data.shape[1])))
+        steps.append(("site_regression", SiteRegressor(sites)))
 
     steps.extend(
         [
@@ -156,11 +149,12 @@ def training_pipeline(
     with parallel_backend("threading", n_jobs=n_jobs):
         cv_results = cross_validate(
             pipe,
-            connectivity_data_site,
+            connectivity_data_frame,
             y_train,
-            cv=cv_strategy,
+            cv=splits,
             scoring=scoring_metrics,
             n_jobs=n_jobs,
+            error_score="raise",
         )
 
     scores_df = pd.DataFrame({k.replace("test_", ""): v for k, v in cv_results.items() if k.startswith("test_")})

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -102,7 +102,7 @@ def training_pipeline(
 
     if task_type == "classification":
         y_train = pd.Series(LabelEncoder().fit_transform(target_labels))  # pyright: ignore[reportArgumentType, reportCallIssue]
-        estimator = LogisticRegression(max_iter=5000, solver="saga", l1_ratio=0.0, random_state=random_state)
+        estimator = LogisticRegression(max_iter=5000, solver="lbfgs", random_state=random_state)
 
         bins = y_train
 

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -16,6 +16,8 @@ from sklearn.model_selection import StratifiedShuffleSplit, cross_validate
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 
+from ..logger import logger
+
 if TYPE_CHECKING:
     from ..base import ConnectivityMatrix
 
@@ -126,8 +128,19 @@ def training_pipeline(
         # Combine bins and sites
         bins = data_frame.agg("_".join, axis=1)
 
+    counts = bins.value_counts()
+    singletons = counts.index[counts == 1]
+    mask = bins.isin(singletons).to_numpy()
+    if mask.any():
+        count = mask.sum().item()
+        logger.warning(f"Excluding {count} {'subject'} that are the only subjects in their subgroups: {singletons.tolist()}")
+    keep = np.flatnonzero(np.logical_not(mask))
+
     cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
-    splits = list(cv_strategy.split(np.zeros(len(bins)), bins))
+    splits = [
+        (keep[train_indices], keep[test_indices])
+        for train_indices, test_indices in cv_strategy.split(np.zeros(keep.size), bins.to_numpy()[keep])
+    ]
 
     steps: list[tuple[str, BaseEstimator]] = [
         # keep_empty_features=True avoids sklearn's "Skipping features without any

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -10,18 +10,19 @@ from numpy.typing import NDArray
 from sklearn.decomposition import PCA  # type: ignore[import-not-found]
 from sklearn.impute import SimpleImputer  # type: ignore[import-not-found]
 from sklearn.linear_model import LogisticRegression, Ridge  # type: ignore[import-not-found]
-from sklearn.model_selection import StratifiedShuffleSplit, cross_validate  # type: ignore[import-not-found]
-from sklearn.pipeline import Pipeline  # type: ignore[import-not-found]
-from sklearn.preprocessing import LabelEncoder, StandardScaler  # type: ignore[import-not-found]
-from sklearn.metrics import ( # type: ignore[import-not-found]
+from sklearn.metrics import (  # type: ignore[import-not-found]
     accuracy_score,
     mean_absolute_error,
     r2_score,
     roc_auc_score,
 )
+from sklearn.model_selection import StratifiedShuffleSplit  # type: ignore[import-not-found]
+from sklearn.pipeline import Pipeline  # type: ignore[import-not-found]
+from sklearn.preprocessing import LabelEncoder, StandardScaler  # type: ignore[import-not-found]
 
 if TYPE_CHECKING:
     from ..base import ConnectivityMatrix
+
 
 def regress_site(
     X_train: NDArray[np.float32],
@@ -39,13 +40,9 @@ def regress_site(
         fill_value=0.0,
     )
 
-    design_train = np.column_stack(
-        [np.ones(len(train_site)), train_site.to_numpy()]
-    )
+    design_train = np.column_stack([np.ones(len(train_site)), train_site.to_numpy()])
 
-    design_test = np.column_stack(
-        [np.ones(len(test_site)), test_site.to_numpy()]
-    )
+    design_test = np.column_stack([np.ones(len(test_site)), test_site.to_numpy()])
 
     beta, *_ = np.linalg.lstsq(
         design_train,
@@ -58,6 +55,7 @@ def regress_site(
     X_test_corr = X_test - design_test[:, 1:] @ beta_site
 
     return X_train_corr, X_test_corr
+
 
 def training_pipeline(
     connectivity_data: NDArray[np.float32],
@@ -92,7 +90,7 @@ def training_pipeline(
         cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
         scoring_metrics = {"accuracy": "accuracy", "roc_auc": "roc_auc"}
         splits = cv_strategy.split(connectivity_data, y)
-        
+
     else:
         y = np.asarray(target_labels)
         estimator = Ridge(alpha=1.0)
@@ -111,7 +109,7 @@ def training_pipeline(
             ("estimator", estimator),
         ]
     )
-    
+
     scores = {metric: [] for metric in scoring_metrics}
 
     with parallel_backend("threading", n_jobs=n_jobs):
@@ -134,24 +132,16 @@ def training_pipeline(
             y_pred = pipe.predict(X_test)
 
             if task_type == "classification":
-                scores["accuracy"].append(
-                    accuracy_score(y_test, y_pred)
-                )
+                scores["accuracy"].append(accuracy_score(y_test, y_pred))
 
                 y_prob = pipe.predict_proba(X_test)[:, 1]
 
-                scores["roc_auc"].append(
-                    roc_auc_score(y_test, y_prob)
-                )
+                scores["roc_auc"].append(roc_auc_score(y_test, y_prob))
 
             else:
-                scores["mae"].append(
-                    mean_absolute_error(y_test, y_pred)
-                )
+                scores["mae"].append(mean_absolute_error(y_test, y_pred))
 
-                scores["r2"].append(
-                    r2_score(y_test, y_pred)
-                )
+                scores["r2"].append(r2_score(y_test, y_pred))
 
     scores_df = pd.DataFrame(scores)
 

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -124,7 +124,9 @@ def training_pipeline(
     splits = list(cv_strategy.split(np.zeros(len(bins)), bins))
 
     steps: list[tuple[str, BaseEstimator]] = [
-        ("imputer", SimpleImputer(strategy="median").set_output(transform="pandas")),
+        # keep_empty_features=True avoids sklearn's "Skipping features without any
+        # observed values" warning.
+        ("imputer", SimpleImputer(strategy="median", keep_empty_features=True).set_output(transform="pandas")),
     ]
 
     if sites is not None:

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -124,7 +124,7 @@ def training_pipeline(
         scoring_metrics = {"mae": "neg_mean_absolute_error", "r2": "r2"}
 
     if sites is not None:
-        data_frame = pd.DataFrame({"site": sites, "bins": bins})
+        data_frame = pd.DataFrame({"site": sites, "bins": bins}).astype(str)
         # Combine bins and sites
         bins = data_frame.agg("_".join, axis=1)
 

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -13,10 +13,51 @@ from sklearn.linear_model import LogisticRegression, Ridge  # type: ignore[impor
 from sklearn.model_selection import StratifiedShuffleSplit, cross_validate  # type: ignore[import-not-found]
 from sklearn.pipeline import Pipeline  # type: ignore[import-not-found]
 from sklearn.preprocessing import LabelEncoder, StandardScaler  # type: ignore[import-not-found]
+from sklearn.metrics import ( # type: ignore[import-not-found]
+    accuracy_score,
+    mean_absolute_error,
+    r2_score,
+    roc_auc_score,
+)
 
 if TYPE_CHECKING:
     from ..base import ConnectivityMatrix
 
+def regress_site(
+    X_train: NDArray[np.float32],
+    X_test: NDArray[np.float32],
+    site_train: NDArray[np.str_],
+    site_test: NDArray[np.str_],
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """Regress out site effects from the training and test data."""
+
+    train_site = pd.get_dummies(site_train, drop_first=True, dtype=float)
+    test_site = pd.get_dummies(site_test, drop_first=True, dtype=float)
+
+    test_site = test_site.reindex(
+        columns=train_site.columns,
+        fill_value=0.0,
+    )
+
+    design_train = np.column_stack(
+        [np.ones(len(train_site)), train_site.to_numpy()]
+    )
+
+    design_test = np.column_stack(
+        [np.ones(len(test_site)), test_site.to_numpy()]
+    )
+
+    beta, *_ = np.linalg.lstsq(
+        design_train,
+        X_train,
+        rcond=None,
+    )
+
+    beta_site = beta[1:, :]
+    X_train_corr = X_train - design_train[:, 1:] @ beta_site
+    X_test_corr = X_test - design_test[:, 1:] @ beta_site
+
+    return X_train_corr, X_test_corr
 
 def training_pipeline(
     connectivity_data: NDArray[np.float32],
@@ -26,6 +67,7 @@ def training_pipeline(
     n_pca: int,
     n_jobs: int = 4,
     random_state: int = 1,
+    sites: NDArray[np.str_] | None = None,
 ) -> pd.DataFrame:
     """Runs a cross-validation pipeline for age or sex prediction.
 
@@ -37,6 +79,7 @@ def training_pipeline(
         n_pca (int): Number of principal components to extract.
         n_jobs (int): Number of cores for parallel calculation.
         random_state (int): Seed for reproducibility.
+        sites (NDArray[np.str_] | None): Site labels for the data.
 
     Returns:
         pd.DataFrame: Statistics (mean, 95% CI) of the scores obtained.
@@ -44,18 +87,19 @@ def training_pipeline(
     connectivity_data = np.asarray(connectivity_data, dtype=np.float32, order="C")
 
     if task_type == "classification":
-        y_train = LabelEncoder().fit_transform(target_labels)
+        y = LabelEncoder().fit_transform(target_labels)
         estimator = LogisticRegression(max_iter=5000, solver="saga", penalty="l2", n_jobs=n_jobs, random_state=random_state)
         cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
         scoring_metrics = {"accuracy": "accuracy", "roc_auc": "roc_auc"}
+        splits = cv_strategy.split(connectivity_data, y)
+        
     else:
-        y_train = np.asarray(target_labels)
+        y = np.asarray(target_labels)
         estimator = Ridge(alpha=1.0)
 
-        bins = pd.qcut(y_train, q=5, labels=False, duplicates="drop")
+        bins = pd.qcut(y, q=5, labels=False, duplicates="drop")
         cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
         splits = list(cv_strategy.split(np.zeros_like(bins), bins))
-        cv_strategy = splits
 
         scoring_metrics = {"mae": "neg_mean_absolute_error", "r2": "r2"}
 
@@ -67,21 +111,54 @@ def training_pipeline(
             ("estimator", estimator),
         ]
     )
+    
+    scores = {metric: [] for metric in scoring_metrics}
 
     with parallel_backend("threading", n_jobs=n_jobs):
-        cv_results = cross_validate(
-            pipe,
-            connectivity_data,
-            y_train,
-            cv=cv_strategy,
-            scoring=scoring_metrics,
-            n_jobs=n_jobs,
-        )
+        for train_idx, test_idx in splits:
+            X_train = connectivity_data[train_idx]
+            X_test = connectivity_data[test_idx]
 
-    scores_df = pd.DataFrame({k.replace("test_", ""): v for k, v in cv_results.items() if k.startswith("test_")})
+            y_train = y[train_idx]
+            y_test = y[test_idx]
+
+            if sites is not None:
+                X_train, X_test = regress_site(
+                    X_train,
+                    X_test,
+                    sites[train_idx],
+                    sites[test_idx],
+                )
+
+            pipe.fit(X_train, y_train)
+            y_pred = pipe.predict(X_test)
+
+            if task_type == "classification":
+                scores["accuracy"].append(
+                    accuracy_score(y_test, y_pred)
+                )
+
+                y_prob = pipe.predict_proba(X_test)[:, 1]
+
+                scores["roc_auc"].append(
+                    roc_auc_score(y_test, y_prob)
+                )
+
+            else:
+                scores["mae"].append(
+                    mean_absolute_error(y_test, y_pred)
+                )
+
+                scores["r2"].append(
+                    r2_score(y_test, y_pred)
+                )
+
+    scores_df = pd.DataFrame(scores)
+
     summary = scores_df.agg(["mean"]).T
     summary["ci_lower"] = scores_df.quantile(0.025)
     summary["ci_upper"] = scores_df.quantile(0.975)
+
     return summary
 
 
@@ -89,6 +166,7 @@ def age_sex_scores(
     connectivity_matrices: List[ConnectivityMatrix],
     ages: NDArray[np.float64],
     genders: NDArray[np.str_],
+    sites: NDArray[np.str_] | None,
     n_splits: int,
     n_pca: int,
     n_jobs: int = 4,
@@ -100,6 +178,7 @@ def age_sex_scores(
         connectivity_matrices (List[ConnectivityMatrix]): List of matrix objects.
         ages: Vector of subject ages.
         genders: Vector of subject genders.
+        sites: Vector of subject sites.
         n_splits (int): Number of splits for cross-validation.
         n_pca (int): Number of PCA components.
         n_jobs (int): Number of joblib threads.
@@ -119,6 +198,7 @@ def age_sex_scores(
         n_pca=n_pca,
         n_jobs=n_jobs,
         random_state=random_state,
+        sites=sites,
     )
 
     age_summary = training_pipeline(
@@ -129,6 +209,7 @@ def age_sex_scores(
         n_pca=n_pca,
         n_jobs=n_jobs,
         random_state=random_state,
+        sites=sites,
     )
 
     return {
@@ -136,8 +217,8 @@ def age_sex_scores(
         "sex_auc_ci_lower": float(sex_summary.loc["roc_auc", "ci_lower"]),  # type: ignore[arg-type]
         "sex_auc_ci_upper": float(sex_summary.loc["roc_auc", "ci_upper"]),  # type: ignore[arg-type]
         "sex_accuracy": float(sex_summary.loc["accuracy", "mean"]),  # type: ignore[arg-type]
-        "age_mae": float(-age_summary.loc["mae", "mean"]),  # type: ignore[arg-type, operator]
-        "age_mae_ci_lower": float(-age_summary.loc["mae", "ci_upper"]),  # type: ignore[arg-type, operator]
-        "age_mae_ci_upper": float(-age_summary.loc["mae", "ci_lower"]),  # type: ignore[arg-type, operator]
+        "age_mae": float(age_summary.loc["mae", "mean"]),  # type: ignore[arg-type, operator]
+        "age_mae_ci_lower": float(age_summary.loc["mae", "ci_lower"]),  # type: ignore[arg-type, operator]
+        "age_mae_ci_upper": float(age_summary.loc["mae", "ci_upper"]),  # type: ignore[arg-type, operator]
         "age_r2": float(age_summary.loc["r2", "mean"]),  # type: ignore[arg-type]
     }

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -43,12 +43,15 @@ class SiteRegressor(BaseEstimator, TransformerMixin):
         Fit the site regressor to the connectivity data.
 
         Args:
-            connectivity_data_site: A 2D array where the first n_connectivity_features columns
-            are connectivity features and the remaining columns are site dummy variables.
+            X: Connectivity data with one row per subject. Its index is used to
+                look up the corresponding site labels in ``self.sites``.
             y: Ignored. This parameter exists for compatibility with the scikit-learn API.
 
         Returns:
             self: Returns the instance itself.
+
+        Raises:
+            ValueError: If the training data contains fewer than two sites.
         """
         fit_sites = np.asarray(self.sites[X.index])
         if np.unique(fit_sites).size < 2:
@@ -63,12 +66,13 @@ class SiteRegressor(BaseEstimator, TransformerMixin):
     def transform(self: SiteRegressor, X: pd.DataFrame) -> pd.DataFrame:  # noqa: N803
         """
         Transform the connectivity data by regressing out site effects.
+
         Args:
-            connectivity_data_site: A 2D array where the first n_connectivity_features columns
-            are connectivity features and the remaining columns are site dummy variables.
+            X: Connectivity data to correct, with one row per subject. Its index
+                is used to look up the corresponding site labels in ``self.sites``.
 
         Returns:
-            A 2D array of connectivity features with site effects regressed out.
+            pd.DataFrame: Connectivity data with the fitted site effects removed.
         """
         return X - self.model.predict(self._get_dummies(X))
 

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -7,16 +7,11 @@ import pandas as pd
 from joblib import parallel_backend  # type: ignore[import-not-found]
 from nilearn.connectome import sym_matrix_to_vec  # type: ignore[import-not-found]
 from numpy.typing import NDArray
+from sklearn.base import BaseEstimator, TransformerMixin  # type: ignore[import-not-found]
 from sklearn.decomposition import PCA  # type: ignore[import-not-found]
 from sklearn.impute import SimpleImputer  # type: ignore[import-not-found]
 from sklearn.linear_model import LogisticRegression, Ridge  # type: ignore[import-not-found]
-from sklearn.metrics import (  # type: ignore[import-not-found]
-    accuracy_score,
-    mean_absolute_error,
-    r2_score,
-    roc_auc_score,
-)
-from sklearn.model_selection import StratifiedShuffleSplit  # type: ignore[import-not-found]
+from sklearn.model_selection import StratifiedShuffleSplit, cross_validate  # type: ignore[import-not-found]
 from sklearn.pipeline import Pipeline  # type: ignore[import-not-found]
 from sklearn.preprocessing import LabelEncoder, StandardScaler  # type: ignore[import-not-found]
 
@@ -24,32 +19,60 @@ if TYPE_CHECKING:
     from ..base import ConnectivityMatrix
 
 
-def regress_site(
-    X_train: NDArray[np.float32],
-    X_test: NDArray[np.float32],
-    site_train: NDArray[np.str_],
-    site_test: NDArray[np.str_],
-) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
-    """Regress out site effects from the training and test data."""
+class SiteRegressor(BaseEstimator, TransformerMixin):
+    """
+    Regress out site effects from connectivity features.
+    """
 
-    train_site = pd.get_dummies(site_train, drop_first=True, dtype=float)
-    test_site = pd.get_dummies(site_test, drop_first=True, dtype=float)
+    def __init__(self: SiteRegressor, n_connectivity_features: int) -> None:
+        """
+        Args:
+            n_connectivity_features: Number of connectivity features in the input data.
+        """
+        self.n_connectivity_features = n_connectivity_features
 
-    test_site = test_site.reindex(
-        columns=train_site.columns,
-        fill_value=0.0,
-    )
+    def fit(self: SiteRegressor, connectivity_data_site: NDArray[np.float32], y: None = None) -> SiteRegressor:
+        """
+        Fit the site regressor to the connectivity data.
 
-    design_train = np.column_stack([np.ones(len(train_site)), train_site.to_numpy()])
+        Args:
+            connectivity_data_site: A 2D array where the first n_connectivity_features columns
+            are connectivity features and the remaining columns are site dummy variables.
+            y: Ignored. This parameter exists for compatibility with the scikit-learn API.
 
-    design_test = np.column_stack([np.ones(len(test_site)), test_site.to_numpy()])
+        Returns:
+            self: Returns the instance itself.
+        """
+        connectivity_feat = connectivity_data_site[:, : self.n_connectivity_features]
+        site = connectivity_data_site[:, self.n_connectivity_features :]
 
-    beta_train, *_ = np.linalg.lstsq(design_train, X_train, rcond=None,)
-    beta_test, *_ = np.linalg.lstsq(design_test, X_test, rcond=None,)
-    X_train_corr = X_train - design_train[:, 1:] @ beta_train[1:, :]
-    X_test_corr = X_test - design_test[:, 1:] @ beta_test[1:, :]
+        # Add intercept
+        design = np.column_stack([np.ones(len(site)), site])
 
-    return X_train_corr, X_test_corr
+        # Estimate coefficients on the training fold only
+        self.beta_ = np.linalg.lstsq(design, connectivity_feat, rcond=None)[0]
+
+        return self
+
+    def transform(self: SiteRegressor, connectivity_data_site: NDArray[np.float32]) -> NDArray[np.float64]:
+        """
+        Transform the connectivity data by regressing out site effects.
+        Args:
+            connectivity_data_site: A 2D array where the first n_connectivity_features columns
+            are connectivity features and the remaining columns are site dummy variables.
+
+        Returns:
+            A 2D array of connectivity features with site effects regressed out.
+        """
+
+        connectivity_feat = connectivity_data_site[:, : self.n_connectivity_features]
+        site = connectivity_data_site[:, self.n_connectivity_features :]
+
+        # Add intercept
+        design = np.column_stack([np.ones(len(site)), site])
+
+        # Remove only the site contribution (keep the intercept)
+        return connectivity_feat - design[:, 1:] @ self.beta_[1:]
 
 
 def training_pipeline(
@@ -79,71 +102,71 @@ def training_pipeline(
     """
     connectivity_data = np.asarray(connectivity_data, dtype=np.float32, order="C")
 
+    # Transform site labels into dummy variables and concatenate with connectivity data
+    if sites is not None:
+        site = pd.get_dummies(
+            sites,
+            drop_first=True,
+            dtype=np.float32,
+        ).to_numpy()
+
+        connectivity_data_site = np.concatenate([connectivity_data, site], axis=1)
+    else:
+        connectivity_data_site = connectivity_data
+
     if task_type == "classification":
-        y = LabelEncoder().fit_transform(target_labels)
+        y_train = LabelEncoder().fit_transform(target_labels)
         estimator = LogisticRegression(max_iter=5000, solver="saga", penalty="l2", n_jobs=n_jobs, random_state=random_state)
         cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
-        scoring_metrics = ["accuracy", "roc_auc"]
-        splits = cv_strategy.split(connectivity_data, y)
-
+        scoring_metrics = {"accuracy": "accuracy", "roc_auc": "roc_auc"}
     else:
-        y = np.asarray(target_labels)
+        y_train = np.asarray(target_labels)
         estimator = Ridge(alpha=1.0)
 
-        bins = pd.qcut(y, q=5, labels=False, duplicates="drop")
+        bins = pd.qcut(y_train, q=5, labels=False, duplicates="drop")
         cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
         splits = list(cv_strategy.split(np.zeros_like(bins), bins))
+        cv_strategy = splits
 
-        scoring_metrics = ["mae", "r2"]
+        scoring_metrics = {"mae": "neg_mean_absolute_error", "r2": "r2"}
 
-    pipe = Pipeline(
+    steps = [
+        ("imputer", SimpleImputer(strategy="median")),
+    ]
+
+    if sites is not None:
+        steps.append(("site_regression", SiteRegressor(connectivity_data.shape[1])))
+
+    steps.extend(
         [
-            ("imputer", SimpleImputer(strategy="median")),
             ("scaler", StandardScaler()),
-            ("pca", PCA(n_components=n_pca, svd_solver="randomized", random_state=random_state)),
+            (
+                "pca",
+                PCA(
+                    n_components=n_pca,
+                    svd_solver="randomized",
+                    random_state=random_state,
+                ),
+            ),
             ("estimator", estimator),
         ]
     )
 
-    scores = {metric: [] for metric in scoring_metrics}
-
+    pipe = Pipeline(steps)
     with parallel_backend("threading", n_jobs=n_jobs):
-        for train_idx, test_idx in splits:
-            X_train = connectivity_data[train_idx]
-            X_test = connectivity_data[test_idx]
+        cv_results = cross_validate(
+            pipe,
+            connectivity_data_site,
+            y_train,
+            cv=cv_strategy,
+            scoring=scoring_metrics,
+            n_jobs=n_jobs,
+        )
 
-            y_train = y[train_idx]
-            y_test = y[test_idx]
-
-            if sites is not None:
-                X_train, X_test = regress_site(
-                    X_train,
-                    X_test,
-                    sites[train_idx],
-                    sites[test_idx],
-                )
-
-            pipe.fit(X_train, y_train)
-            y_pred = pipe.predict(X_test)
-
-            if task_type == "classification":
-                scores["accuracy"].append(accuracy_score(y_test, y_pred))
-
-                y_prob = pipe.predict_proba(X_test)[:, 1]
-
-                scores["roc_auc"].append(roc_auc_score(y_test, y_prob))
-
-            else:
-                scores["mae"].append(mean_absolute_error(y_test, y_pred))
-
-                scores["r2"].append(r2_score(y_test, y_pred))
-
-    scores_df = pd.DataFrame(scores)
-
+    scores_df = pd.DataFrame({k.replace("test_", ""): v for k, v in cv_results.items() if k.startswith("test_")})
     summary = scores_df.agg(["mean"]).T
     summary["ci_lower"] = scores_df.quantile(0.025)
     summary["ci_upper"] = scores_df.quantile(0.975)
-
     return summary
 
 
@@ -202,8 +225,8 @@ def age_sex_scores(
         "sex_auc_ci_lower": float(sex_summary.loc["roc_auc", "ci_lower"]),  # type: ignore[arg-type]
         "sex_auc_ci_upper": float(sex_summary.loc["roc_auc", "ci_upper"]),  # type: ignore[arg-type]
         "sex_accuracy": float(sex_summary.loc["accuracy", "mean"]),  # type: ignore[arg-type]
-        "age_mae": float(age_summary.loc["mae", "mean"]),  # type: ignore[arg-type, operator]
-        "age_mae_ci_lower": float(age_summary.loc["mae", "ci_lower"]),  # type: ignore[arg-type, operator]
-        "age_mae_ci_upper": float(age_summary.loc["mae", "ci_upper"]),  # type: ignore[arg-type, operator]
+        "age_mae": float(-age_summary.loc["mae", "mean"]),  # type: ignore[arg-type, operator]
+        "age_mae_ci_lower": float(-age_summary.loc["mae", "ci_upper"]),  # type: ignore[arg-type, operator]
+        "age_mae_ci_upper": float(-age_summary.loc["mae", "ci_lower"]),  # type: ignore[arg-type, operator]
         "age_r2": float(age_summary.loc["r2", "mean"]),  # type: ignore[arg-type]
     }

--- a/wonkyconn/features/age_sex_prediction.py
+++ b/wonkyconn/features/age_sex_prediction.py
@@ -108,21 +108,23 @@ def training_pipeline(
         y_train = pd.Series(LabelEncoder().fit_transform(target_labels))  # pyright: ignore[reportArgumentType, reportCallIssue]
         estimator = LogisticRegression(max_iter=5000, solver="lbfgs", random_state=random_state)
 
-        bins = y_train
+        bins = pd.Series(target_labels)
 
         scoring_metrics = {"accuracy": "accuracy", "roc_auc": "roc_auc"}
     else:
         y_train = pd.Series(target_labels)
         estimator = Ridge(alpha=1.0)
 
-        bins = pd.qcut(y_train, q=5, labels=False, duplicates="drop")
+        bins, edges = pd.qcut(y_train, q=5, labels=False, retbins=True, duplicates="drop")
+        labels = pd.Series([f"age-group-{int(round(edges[i]))}-{int(round(edges[i + 1]))}" for i in range(len(edges) - 1)])
+        bins = bins.map(labels)
 
         scoring_metrics = {"mae": "neg_mean_absolute_error", "r2": "r2"}
 
     if sites is not None:
         data_frame = pd.DataFrame({"site": sites, "bins": bins})
-        # Get unique row indices as combined bins
-        bins = data_frame.groupby(data_frame.columns.tolist(), sort=False).ngroup()
+        # Combine bins and sites
+        bins = data_frame.agg("_".join, axis=1)
 
     cv_strategy = StratifiedShuffleSplit(n_splits=n_splits, test_size=0.2, random_state=random_state)
     splits = list(cv_strategy.split(np.zeros(len(bins)), bins))

--- a/wonkyconn/features/calculate_degrees_of_freedom.py
+++ b/wonkyconn/features/calculate_degrees_of_freedom.py
@@ -98,5 +98,5 @@ def calculate_for_key(
         else:
             raise ValueError(f"Unexpected value for `{keys}`: {value}")
 
-    percentages = pd.Series(proportions) * 100
+    percentages: pd.Series = pd.Series(proportions) * 100
     return percentages.mean()

--- a/wonkyconn/features/calculate_gradients_correlation.py
+++ b/wonkyconn/features/calculate_gradients_correlation.py
@@ -48,8 +48,8 @@ def remove_nan_roi_atlas(atlas: nib.Nifti1Image, kept_idx: np.ndarray) -> Nifti1
         kept_idx (np.ndarray): Indices of rows/columns kept after NaN removal.
 
     Returns:
-        tuple[nib.Nifti1Image, list[int]]: Atlas image with only kept ROIs and
-            the list of kept label values.
+        nib.Nifti1Image: Atlas image containing only the kept ROIs, with removed
+            regions set to zero.
     """
 
     # Load atlas

--- a/wonkyconn/features/calculate_gradients_correlation.py
+++ b/wonkyconn/features/calculate_gradients_correlation.py
@@ -4,10 +4,10 @@ from typing import Iterable, List, Tuple
 
 import nibabel as nib
 import numpy as np
-from brainspace.gradient import GradientMaps  # type: ignore[import-not-found]
-from nilearn import image  # type: ignore[import-not-found]
-from nilearn.connectome import sym_matrix_to_vec, vec_to_sym_matrix  # type: ignore[import-not-found]
-from nilearn.maskers import NiftiLabelsMasker  # type: ignore[import-not-found]
+from brainspace.gradient import GradientMaps
+from nilearn import image
+from nilearn.connectome import sym_matrix_to_vec, vec_to_sym_matrix
+from nilearn.maskers import NiftiLabelsMasker
 from scipy import stats
 
 from ..base import ConnectivityMatrix

--- a/wonkyconn/features/calculate_gradients_correlation.py
+++ b/wonkyconn/features/calculate_gradients_correlation.py
@@ -5,6 +5,7 @@ from typing import Iterable, List, Tuple
 import nibabel as nib
 import numpy as np
 from brainspace.gradient import GradientMaps
+from nibabel.nifti1 import Nifti1Image
 from nilearn import image
 from nilearn.connectome import sym_matrix_to_vec, vec_to_sym_matrix
 from nilearn.maskers import NiftiLabelsMasker
@@ -38,7 +39,7 @@ def remove_nan_from_matrix(matrix: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     return conn_clean, kept_idx
 
 
-def remove_nan_roi_atlas(atlas: nib.Nifti1Image, kept_idx: np.ndarray) -> nib.Nifti1Image:
+def remove_nan_roi_atlas(atlas: nib.Nifti1Image, kept_idx: np.ndarray) -> Nifti1Image:
     """Remove ROIs from an atlas that are not present in a connectivity matrix.
 
     Args:
@@ -62,10 +63,10 @@ def remove_nan_roi_atlas(atlas: nib.Nifti1Image, kept_idx: np.ndarray) -> nib.Ni
     keep_mask = np.isin(atlas_data, kept_labels)
     kept_atlas_data = atlas_data.copy()
     kept_atlas_data[~keep_mask] = 0
-    return nib.Nifti1Image(kept_atlas_data, atlas.affine, atlas.header), kept_labels
+    return Nifti1Image(kept_atlas_data, atlas.affine, atlas.header)
 
 
-def overlapping_atlas_with_mask(subject_atlas: nib.Nifti1Image, group_mask: nib.Nifti1Image) -> nib.Nifti1Image:
+def overlapping_atlas_with_mask(subject_atlas: Nifti1Image, group_mask: Nifti1Image) -> Nifti1Image:
     """Create a new atlas containing only regions that overlap with the group gradient mask.
 
     Args:
@@ -76,9 +77,9 @@ def overlapping_atlas_with_mask(subject_atlas: nib.Nifti1Image, group_mask: nib.
         nib.Nifti1Image: Atlas with non-overlapping regions zeroed out.
     """
 
-    mask_gradient_resampled = image.resample_to_img(
+    mask_gradient_resampled: Nifti1Image = image.resample_to_img(
         group_mask, subject_atlas, interpolation="nearest", copy_header=True, force_resample=True
-    )
+    )  # pyright: ignore[reportAssignmentType]
 
     # Get arrays
     atlas_data = subject_atlas.get_fdata()
@@ -153,7 +154,7 @@ def process_single_matrix(
     """
     matrix = np.asarray(connectivity_matrix, dtype=np.float64)
     conn_clean, kept_idx = remove_nan_from_matrix(matrix)
-    atlas_mask_without_nan, _ = remove_nan_roi_atlas(atlas, kept_idx)
+    atlas_mask_without_nan = remove_nan_roi_atlas(atlas, kept_idx)
 
     # filter out labels > 400
     atlas_data = atlas_mask_without_nan.get_fdata()
@@ -180,7 +181,7 @@ def process_single_matrix(
     gm = GradientMaps(approach="pca", n_components=5, alignment="procrustes", kernel="normalized_angle")
     ind_gradient = gm.fit(masked_matrix, reference=group_gradients_np)
 
-    return ind_gradient.aligned_, group_gradients_np
+    return ind_gradient.aligned_, group_gradients_np  # pyright: ignore[reportReturnType]
 
 
 def extract_gradients(
@@ -201,11 +202,11 @@ def extract_gradients(
     repo_root = Path(__file__).resolve().parent.parent
 
     path_gradients = repo_root / "data" / "gradients"
-    gradient_mask = nib.load(path_gradients / "gradientmask_cortical.nii.gz")
+    gradient_mask = nib.nifti1.load(path_gradients / "gradientmask_cortical.nii.gz")  # pyright: ignore[reportAttributeAccessIssue]
 
     # Load all group gradient templates
     gradient_files = sorted(glob.glob(str(path_gradients / "templates" / "gradient*_cortical_only.nii.gz")))
-    gradient_imgs = [nib.load(fname) for fname in gradient_files]
+    gradient_imgs = [nib.nifti1.load(fname) for fname in gradient_files]  # pyright: ignore[reportAttributeAccessIssue]
 
     mean_connectome = group_mean_connectivity(connectivity_matrices)
     gradient_aligned, template_gradient = process_single_matrix(mean_connectome, atlas, gradient_mask, gradient_imgs)

--- a/wonkyconn/features/calculate_gradients_correlation.py
+++ b/wonkyconn/features/calculate_gradients_correlation.py
@@ -1,4 +1,5 @@
 import glob
+import warnings
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
@@ -128,7 +129,10 @@ def group_mean_connectivity(
     matrices = [np.asarray(cm.load(), dtype=np.float64) for cm in connectivity_matrices]
     matrices_vec = [sym_matrix_to_vec(mat, discard_diagonal=False) for mat in matrices]
 
-    mean_vec = np.nanmean(matrices_vec, axis=0)
+    with warnings.catch_warnings():
+        # Edges that are NaN across all subjects yield all-NaN slices; the NaN is intended.
+        warnings.simplefilter("ignore", RuntimeWarning)
+        mean_vec = np.nanmean(matrices_vec, axis=0)
     mean_matrix = vec_to_sym_matrix(mean_vec, diagonal=None)
 
     return mean_matrix

--- a/wonkyconn/features/distance_dependence.py
+++ b/wonkyconn/features/distance_dependence.py
@@ -19,5 +19,5 @@ def calculate_distance_dependence(qcfc: pd.DataFrame, distance_matrix: npt.NDArr
     """
     i, j = map(np.asarray, zip(*qcfc.index, strict=False))
     distance_vector = distance_matrix[i, j]
-    r, _ = spearmanr(distance_vector, qcfc.correlation, nan_policy="omit")
-    return np.abs(r)
+    statistic, _ = spearmanr(distance_vector, qcfc.correlation, nan_policy="omit")
+    return np.abs(statistic).item()  # pyright: ignore[reportArgumentType, reportCallIssue]

--- a/wonkyconn/features/network.py
+++ b/wonkyconn/features/network.py
@@ -45,8 +45,8 @@ def single_subject_within_network_connectivity(
         roi_index -= 1
 
     # calculate similarity of the thresholded individual level seed based connectivity with the binary mask
-    subj_average_connectivity_within_network = []
-    subj_variance_connectivity_within_network = []
+    subj_average_connectivity_within_network_list = []
+    subj_variance_connectivity_within_network_list = []
     subj_corr_with_network = []
     for idx_roi in roi_index:
         seed_based_map = connectivity_matrix.load()[int(idx_roi), :]
@@ -72,13 +72,13 @@ def single_subject_within_network_connectivity(
             seed_based_map[mask], region_membership[f"yeo7-{yeo_network_index}"].to_numpy()[mask]
         )
 
-        subj_average_connectivity_within_network.append(mean_within_network_connection)
-        subj_variance_connectivity_within_network.append(std_within_network_connection)
+        subj_average_connectivity_within_network_list.append(mean_within_network_connection)
+        subj_variance_connectivity_within_network_list.append(std_within_network_connection)
         subj_corr_with_network.append(correlation_with_given_network[1, 0])
 
     # summarise of the given subject
-    subj_average_connectivity_within_network = np.asarray(subj_average_connectivity_within_network).mean(axis=0)
-    subj_variance_connectivity_within_network = np.asarray(subj_variance_connectivity_within_network).mean(axis=0)
+    subj_average_connectivity_within_network = np.asarray(subj_average_connectivity_within_network_list).mean(axis=0)
+    subj_variance_connectivity_within_network = np.asarray(subj_variance_connectivity_within_network_list).mean(axis=0)
     return (
         subj_average_connectivity_within_network,
         subj_variance_connectivity_within_network,

--- a/wonkyconn/features/network.py
+++ b/wonkyconn/features/network.py
@@ -4,6 +4,7 @@ from __future__ import (
     annotations,
 )
 
+import warnings
 from typing import Tuple
 
 import numpy as np
@@ -57,8 +58,10 @@ def single_subject_within_network_connectivity(
         ]
         networks = np.asarray(isolate_parcel)
         networks[networks == 0] = np.nan
-        mean_within_network_connection = np.nanmean(networks, axis=1)
-        std_within_network_connection = np.nanstd(networks, axis=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            mean_within_network_connection = np.nanmean(networks, axis=1)
+            std_within_network_connection = np.nanstd(networks, axis=1)
 
         # Remove rows with NaN values
         mask = np.array(
@@ -68,9 +71,11 @@ def single_subject_within_network_connectivity(
             ]
         )
 
-        correlation_with_given_network = np.corrcoef(
-            seed_based_map[mask], region_membership[f"yeo7-{yeo_network_index}"].to_numpy()[mask]
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            correlation_with_given_network = np.corrcoef(
+                seed_based_map[mask], region_membership[f"yeo7-{yeo_network_index}"].to_numpy()[mask]
+            )
 
         subj_average_connectivity_within_network_list.append(mean_within_network_connection)
         subj_variance_connectivity_within_network_list.append(std_within_network_connection)

--- a/wonkyconn/features/network.py
+++ b/wonkyconn/features/network.py
@@ -82,7 +82,7 @@ def single_subject_within_network_connectivity(
     return (
         subj_average_connectivity_within_network,
         subj_variance_connectivity_within_network,
-        np.nanmean(subj_corr_with_network),
+        np.nanmean(subj_corr_with_network),  # pyright: ignore[reportReturnType]
     )
 
 

--- a/wonkyconn/features/quality_control_connectivity.py
+++ b/wonkyconn/features/quality_control_connectivity.py
@@ -28,7 +28,7 @@ def calculate_qcfc(
     For each edge, we then computed the correlation between the weight of
     that edge and the mean relative RMS motion.
     QC-FC relationships were calculated as partial correlations that
-    accounted for participant age and sex
+    accounted for participant age and sex (and site when ``site_correction`` is enabled).
 
     Parameters:
         data_frame (pd.DataFrame): The data frame containing the covariates "age" and "gender".
@@ -36,6 +36,8 @@ def calculate_qcfc(
                                    It needs to have one row for each connectivity matrix.
         connectivity_matrices (Iterable[ConnectivityMatrix]): The connectivity matrices to calculate QCFC for.
         metric_key (str, optional): The key of the metric to use for QCFC calculation. Defaults to "MeanFramewiseDisplacement".
+        site_correction (bool, optional): If True, include site as an additional covariate
+                                   (requires a "site" column in ``data_frame``). Defaults to False.
 
     Returns:
         pd.DataFrame: The QCFC values between connectivity matrices and the metric.

--- a/wonkyconn/features/quality_control_connectivity.py
+++ b/wonkyconn/features/quality_control_connectivity.py
@@ -70,7 +70,8 @@ def calculate_qcfc(
         axis=1,
     )
 
-    correlation, count = partial_correlation(connectivity_array, metrics, covariates)  # pyright: ignore[reportCallIssue]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        correlation, count = partial_correlation(connectivity_array, metrics, covariates)  # pyright: ignore[reportCallIssue]
     p_value = correlation_p_value(correlation, count)
 
     qcfc = pd.DataFrame(dict(i=i, j=j, correlation=correlation, p_value=p_value))

--- a/wonkyconn/features/quality_control_connectivity.py
+++ b/wonkyconn/features/quality_control_connectivity.py
@@ -31,7 +31,7 @@ def calculate_qcfc(
     accounted for participant age and sex
 
     Parameters:
-        data_frame (pd.DataFrame): The data frame containing the covariates "age" and "gender". 
+        data_frame (pd.DataFrame): The data frame containing the covariates "age" and "gender".
                                    "site" is also required if site correction is applied.
                                    It needs to have one row for each connectivity matrix.
         connectivity_matrices (Iterable[ConnectivityMatrix]): The connectivity matrices to calculate QCFC for.

--- a/wonkyconn/features/quality_control_connectivity.py
+++ b/wonkyconn/features/quality_control_connectivity.py
@@ -20,6 +20,7 @@ def calculate_qcfc(
     data_frame: pd.DataFrame,
     connectivity_matrices: Iterable[ConnectivityMatrix],
     metric_key: str = "MeanFramewiseDisplacement",
+    site_correction: bool = False,
 ) -> pd.DataFrame:
     """
     metric calculation: quality control / functional connectivity
@@ -30,7 +31,8 @@ def calculate_qcfc(
     accounted for participant age and sex
 
     Parameters:
-        data_frame (pd.DataFrame): The data frame containing the covariates "age" and "gender".
+        data_frame (pd.DataFrame): The data frame containing the covariates "age" and "gender". 
+                                   "site" is also required if site correction is applied.
                                    It needs to have one row for each connectivity matrix.
         connectivity_matrices (Iterable[ConnectivityMatrix]): The connectivity matrices to calculate QCFC for.
         metric_key (str, optional): The key of the metric to use for QCFC calculation. Defaults to "MeanFramewiseDisplacement".
@@ -44,7 +46,10 @@ def calculate_qcfc(
     )
     if np.isnan(metrics).all():
         raise ValueError(f"None of the connectivity matrices have a metric with key '{metric_key}'")
-    covariates = np.asarray(dmatrix("age + gender", data_frame))
+    if site_correction:
+        covariates = np.asarray(dmatrix("age + C(gender) + C(site)", data_frame))
+    else:
+        covariates = np.asarray(dmatrix("age + C(gender)", data_frame))
 
     connectivity_arrays = [
         connectivity_matrix.load()

--- a/wonkyconn/features/quality_control_connectivity.py
+++ b/wonkyconn/features/quality_control_connectivity.py
@@ -70,7 +70,7 @@ def calculate_qcfc(
         axis=1,
     )
 
-    correlation, count = partial_correlation(connectivity_array, metrics, covariates)
+    correlation, count = partial_correlation(connectivity_array, metrics, covariates)  # pyright: ignore[reportCallIssue]
     p_value = correlation_p_value(correlation, count)
 
     qcfc = pd.DataFrame(dict(i=i, j=j, correlation=correlation, p_value=p_value))
@@ -100,7 +100,7 @@ def significant_level(x: "pd.Series[float]", alpha: float = 0.05, correction: st
         res, _, _, _ = multipletests(x, alpha=alpha, method=correction)
     else:
         res = x < alpha
-    return res
+    return np.asarray(res)
 
 
 def calculate_qcfc_percentage(qcfc: pd.DataFrame) -> float:

--- a/wonkyconn/features/tests/test_network.py
+++ b/wonkyconn/features/tests/test_network.py
@@ -22,9 +22,9 @@ def test_single_subject_within_network_connectivity(data_path: Path) -> None:  #
         / "halfpipe/derivatives/halfpipe/"
         / "sub-10171/func/task-rest/sub-10171_task-rest_feature-cCompCor_atlas-Schaefer2018Combined_timeseries.json"
     )
-    dl.get(str(dseg_path))
-    dl.get(str(relmat_path))
-    dl.get(str(metadata_path))
+    dl.get(str(dseg_path))  # pyright: ignore[reportAttributeAccessIssue]
+    dl.get(str(relmat_path))  # pyright: ignore[reportAttributeAccessIssue]
+    dl.get(str(metadata_path))  # pyright: ignore[reportAttributeAccessIssue]
     atlas = Atlas.create("Schaefer2018Combined", dseg_path)
     with metadata_path.open("r") as file:
         metadata = json.load(file)

--- a/wonkyconn/features/tests/test_prediction.py
+++ b/wonkyconn/features/tests/test_prediction.py
@@ -1,0 +1,146 @@
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.typing import NDArray
+
+from wonkyconn.features.age_sex_prediction import training_pipeline
+
+subject_count = 128
+feature_count = 4_096
+random_state = 1
+
+Task = Literal["classification", "regression"]
+
+# Alternating site assignment reused both for confounded data generation and for
+# the ``sites`` parametrization below, so the two stay perfectly aligned.
+site_labels = np.array(["site-a", "site-b"] * (subject_count // 2))
+
+
+@dataclass(frozen=True)
+class Config:
+    task: Task
+    is_predictable: bool = False
+    # When True, the site drives both the features and the labels, so the target
+    # is only predictable while the site effect is present in the features.
+    is_site_confounded: bool = False
+
+
+@dataclass(frozen=True)
+class Dataset:
+    config: Config
+    connectivity_data: NDArray[np.float32]
+    target_labels: NDArray[np.float64] | NDArray[np.str_]
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(Config(task="classification", is_predictable=False), id="binary-random-labels"),
+        pytest.param(Config(task="classification", is_predictable=True), id="binary-predictable-labels"),
+        pytest.param(Config(task="regression", is_predictable=False), id="continuous-random-labels"),
+        pytest.param(Config(task="regression", is_predictable=True), id="continuous-predictable-labels"),
+        pytest.param(Config(task="classification", is_site_confounded=True), id="binary-site-confounded-labels"),
+        pytest.param(Config(task="regression", is_site_confounded=True), id="continuous-site-confounded-labels"),
+    ],
+)
+def dataset(request: pytest.FixtureRequest) -> Dataset:
+    config: Config = request.param
+
+    rng = np.random.default_rng(random_state)
+
+    labels: NDArray[np.float64] | NDArray[np.str_]
+    if config.is_site_confounded:
+        # Site drives the features (via ``site_code``) and the labels together,
+        # so the target is recoverable only until the site effect is removed.
+        site_code = np.where(site_labels == "site-a", 1.0, -1.0)
+        loadings = rng.normal(size=feature_count)
+        connectivity_data = (
+            np.outer(site_code, loadings) + rng.normal(scale=0.3, size=(subject_count, feature_count))
+        ).astype(np.float32)
+        match config.task:
+            case "classification":
+                labels = np.where(site_labels == "site-a", "male", "female")
+            case "regression":
+                labels = np.where(site_labels == "site-a", 30.0, 60.0) + rng.normal(scale=2.0, size=subject_count)
+    else:
+        latent = rng.normal(size=subject_count)
+        loadings = rng.normal(size=feature_count)
+        connectivity_data = (np.outer(latent, loadings) + rng.normal(scale=0.3, size=(subject_count, feature_count))).astype(
+            np.float32
+        )
+        match config.task:
+            case "classification":
+                if config.is_predictable:
+                    score = latent + rng.normal(scale=0.5, size=subject_count)
+                    labels = np.where(score > np.median(score), "male", "female")
+                else:
+                    labels = np.array(["female", "male"] * (subject_count // 2))
+                    rng.shuffle(labels)
+            case "regression":
+                noise = rng.normal(scale=0.5, size=subject_count)
+                raw = latent + noise if config.is_predictable else rng.normal(size=subject_count)
+                # Rescale to a plausible age range.
+                labels = 18.0 + (raw - raw.min()) / (raw.max() - raw.min()) * 62.0
+
+    return Dataset(
+        config=config,
+        connectivity_data=connectivity_data,
+        target_labels=labels,
+    )
+
+
+@pytest.mark.parametrize(
+    "sites",
+    [
+        pytest.param(None, id="without-sites"),
+        pytest.param(site_labels, id="with-sites"),
+    ],
+)
+def test_training_pipeline(
+    dataset: Dataset,
+    sites: NDArray[np.str_] | None,
+) -> None:
+    if dataset.config.task == "classification":
+        expected_metrics = frozenset({"accuracy", "roc_auc"})
+        primary_metric = "roc_auc"
+        learnable_threshold = 0.8
+        chance_ceiling = 0.65
+    else:
+        expected_metrics = frozenset({"mae", "r2"})
+        primary_metric = "r2"
+        learnable_threshold = 0.3
+        chance_ceiling = 0.2
+
+    summary = training_pipeline(
+        dataset.connectivity_data,
+        dataset.target_labels,
+        task_type=dataset.config.task,
+        n_splits=3,
+        n_pca=5,
+        n_jobs=1,
+        random_state=42,
+        sites=sites,
+    )
+
+    assert isinstance(summary, pd.DataFrame)
+    assert set(summary.index) == expected_metrics
+    assert list(summary.columns) == ["mean", "ci_lower", "ci_upper"]
+    assert np.isfinite(summary.to_numpy()).all()
+    assert (summary["ci_lower"] <= summary["mean"]).all()
+    assert (summary["mean"] <= summary["ci_upper"]).all()
+
+    score = float(summary.loc[primary_metric, "mean"])  # type: ignore[arg-type]
+
+    if dataset.config.is_site_confounded:
+        if sites is None:
+            # Without correction the site confound is fully exploitable.
+            assert score > learnable_threshold
+        else:
+            # Site-effect correction must strip the confound, dropping the
+            # otherwise-perfect prediction back to chance level.
+            assert score < chance_ceiling
+    elif dataset.config.is_predictable:
+        # Labels that carry signal should be recovered above the chance baseline.
+        assert score > learnable_threshold

--- a/wonkyconn/features/tests/test_prediction.py
+++ b/wonkyconn/features/tests/test_prediction.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 import numpy as np
@@ -6,7 +7,8 @@ import pandas as pd
 import pytest
 from numpy.typing import NDArray
 
-from wonkyconn.features.age_sex_prediction import training_pipeline
+from wonkyconn.base import ConnectivityMatrix
+from wonkyconn.features.age_sex_prediction import SiteRegressor, age_sex_scores, training_pipeline
 
 subject_count = 128
 feature_count = 4_096
@@ -145,3 +147,30 @@ def test_training_pipeline(
     else:
         # Random labels should not be recoverable above chance level.
         assert score < chance_ceiling
+
+
+def test_age_sex_scores(tmp_path: Path) -> None:
+    rng = np.random.default_rng(random_state)
+
+    region_count = np.sqrt(feature_count).astype(int).item()
+
+    matrices = []
+    for i in range(subject_count):
+        square = rng.normal(size=(region_count, region_count)).astype(np.float32)
+        path = tmp_path / f"sub-{i}.tsv"
+        np.savetxt(path, square + square.T, delimiter="\t")
+        matrices.append(ConnectivityMatrix(path, metadata=dict()))
+
+    ages = rng.uniform(18.0, 80.0, subject_count)
+    genders = np.array(["m", "f"] * (subject_count // 2))
+    sites = np.array(["site-a", "site-b"] * (subject_count // 2))
+
+    scores = age_sex_scores(matrices, ages, genders, sites, n_splits=3, n_pca=5, n_jobs=1)
+    assert len(scores) == 8
+    assert all(np.isfinite(value) for value in scores.values())
+
+
+def test_site_regressor_requires_two_sites() -> None:
+    regressor = SiteRegressor(np.array(["site-a", "site-a"]))
+    with pytest.raises(ValueError, match="at least two sites"):
+        regressor.fit(pd.DataFrame(np.zeros((2, 3), dtype=np.float32)))

--- a/wonkyconn/features/tests/test_prediction.py
+++ b/wonkyconn/features/tests/test_prediction.py
@@ -178,15 +178,15 @@ def test_site_regressor_requires_two_sites() -> None:
         regressor.fit(pd.DataFrame(np.zeros((2, 3), dtype=np.float32)))
 
 
-def test_training_pipeline_singleton_classes() -> None:
+def test_training_pipeline_exclude_singleton_classes(caplog: pytest.LogCaptureFixture) -> None:
     labels = np.array(["male"] * 10 + ["female"] * 10)
     sites = np.array(["site-a"] * 5 + ["site-b"] * 5 + ["site-a"] * 9 + ["site-b"] * 1)
 
     rng = np.random.default_rng(random_state)
     connectivity_data = rng.normal(size=(len(labels), feature_count)).astype(np.float32)
 
-    with pytest.raises(ValueError, match=r"least populated classes in y have only 1 member") as exc_info:
-        training_pipeline(
+    with caplog.at_level("WARNING"):
+        summary = training_pipeline(
             connectivity_data,
             labels,
             task_type="classification",
@@ -196,4 +196,8 @@ def test_training_pipeline_singleton_classes() -> None:
             random_state=random_state,
             sites=sites,
         )
-    assert "site-b_female" in str(exc_info.value)
+
+    assert isinstance(summary, pd.DataFrame)
+    assert set(summary.index) == {"accuracy", "roc_auc"}
+    assert np.isfinite(summary.to_numpy()).all()
+    assert "site-b_female" in caplog.text

--- a/wonkyconn/features/tests/test_prediction.py
+++ b/wonkyconn/features/tests/test_prediction.py
@@ -176,3 +176,24 @@ def test_site_regressor_requires_two_sites() -> None:
     regressor = SiteRegressor(np.array(["site-a", "site-a"]))
     with pytest.raises(ValueError, match="at least two sites"):
         regressor.fit(pd.DataFrame(np.zeros((2, 3), dtype=np.float32)))
+
+
+def test_training_pipeline_singleton_classes() -> None:
+    labels = np.array(["male"] * 10 + ["female"] * 10)
+    sites = np.array(["site-a"] * 5 + ["site-b"] * 5 + ["site-a"] * 9 + ["site-b"] * 1)
+
+    rng = np.random.default_rng(random_state)
+    connectivity_data = rng.normal(size=(len(labels), feature_count)).astype(np.float32)
+
+    with pytest.raises(ValueError, match=r"least populated classes in y have only 1 member") as exc_info:
+        training_pipeline(
+            connectivity_data,
+            labels,
+            task_type="classification",
+            n_splits=3,
+            n_pca=5,
+            n_jobs=1,
+            random_state=random_state,
+            sites=sites,
+        )
+    assert "site-b_female" in str(exc_info.value)

--- a/wonkyconn/features/tests/test_prediction.py
+++ b/wonkyconn/features/tests/test_prediction.py
@@ -201,3 +201,26 @@ def test_training_pipeline_exclude_singleton_classes(caplog: pytest.LogCaptureFi
     assert set(summary.index) == {"accuracy", "roc_auc"}
     assert np.isfinite(summary.to_numpy()).all()
     assert "site-b_female" in caplog.text
+
+
+def test_training_pipeline_numeric_sites() -> None:
+    labels = np.array(["male", "female"] * 10)
+    sites = np.array([1.0, 2.0] * 10)
+
+    rng = np.random.default_rng(random_state)
+    connectivity_data = rng.normal(size=(len(labels), feature_count)).astype(np.float32)
+
+    summary = training_pipeline(
+        connectivity_data,
+        labels,
+        task_type="classification",
+        n_splits=3,
+        n_pca=5,
+        n_jobs=1,
+        random_state=random_state,
+        sites=sites,
+    )
+
+    assert isinstance(summary, pd.DataFrame)
+    assert set(summary.index) == {"accuracy", "roc_auc"}
+    assert np.isfinite(summary.to_numpy()).all()

--- a/wonkyconn/features/tests/test_prediction.py
+++ b/wonkyconn/features/tests/test_prediction.py
@@ -70,17 +70,15 @@ def dataset(request: pytest.FixtureRequest) -> Dataset:
         connectivity_data = (np.outer(latent, loadings) + rng.normal(scale=0.3, size=(subject_count, feature_count))).astype(
             np.float32
         )
+        noise = rng.normal(scale=0.5, size=subject_count)
         match config.task:
             case "classification":
-                if config.is_predictable:
-                    score = latent + rng.normal(scale=0.5, size=subject_count)
-                    labels = np.where(score > np.median(score), "male", "female")
-                else:
-                    labels = np.array(["female", "male"] * (subject_count // 2))
+                score = latent + noise
+                labels = np.where(score > np.median(score), "male", "female")
+                if not config.is_predictable:
                     rng.shuffle(labels)
             case "regression":
-                noise = rng.normal(scale=0.5, size=subject_count)
-                raw = latent + noise if config.is_predictable else rng.normal(size=subject_count)
+                raw = (latent + noise) if config.is_predictable else (noise + noise)
                 # Rescale to a plausible age range.
                 labels = 18.0 + (raw - raw.min()) / (raw.max() - raw.min()) * 62.0
 
@@ -144,3 +142,6 @@ def test_training_pipeline(
     elif dataset.config.is_predictable:
         # Labels that carry signal should be recovered above the chance baseline.
         assert score > learnable_threshold
+    else:
+        # Random labels should not be recoverable above chance level.
+        assert score < chance_ceiling

--- a/wonkyconn/features/tests/test_prediction.py
+++ b/wonkyconn/features/tests/test_prediction.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 
 import numpy as np
 import pandas as pd
@@ -10,92 +10,94 @@ from numpy.typing import NDArray
 from wonkyconn.base import ConnectivityMatrix
 from wonkyconn.features.age_sex_prediction import SiteRegressor, age_sex_scores, training_pipeline
 
-subject_count = 128
+subject_count = 192
 feature_count = 4_096
 random_state = 1
 
-Task = Literal["classification", "regression"]
-
-# Alternating site assignment reused both for confounded data generation and for
-# the ``sites`` parametrization below, so the two stay perfectly aligned.
 site_labels = np.array(["site-a", "site-b"] * (subject_count // 2))
 
 
 @dataclass(frozen=True)
 class Config:
-    task: Task
-    is_predictable: bool = False
-    # When True, the site drives both the features and the labels, so the target
-    # is only predictable while the site effect is present in the features.
-    is_site_confounded: bool = False
+    task: Literal["classification", "regression"]
+    # How the target relates to the connectivity features:
+    #   "random"          - labels are independent noise (nothing to learn)
+    #   "predictable"     - a latent factor drives both features and labels
+    #   "site-confounded" - the site drives both features and labels
+    signal: Literal["random", "predictable", "site-confounded"]
 
 
 @dataclass(frozen=True)
 class Dataset:
     config: Config
     connectivity_data: NDArray[np.float32]
-    target_labels: NDArray[np.float64] | NDArray[np.str_]
+    labels: NDArray[np.float64] | NDArray[np.str_]
+
+
+def sex(score: NDArray[np.float64]) -> NDArray[np.str_]:
+    """Convert a continuous score to a binary sex label based on the mean."""
+    return np.where(score > np.mean(score), "male", "female")
+
+
+def age(score: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Convert a continuous score to an age label based on a linear transformation."""
+    return 18.0 + (score - score.min()) / (score.max() - score.min()) * 62.0
 
 
 @pytest.fixture(
     params=[
-        pytest.param(Config(task="classification", is_predictable=False), id="binary-random-labels"),
-        pytest.param(Config(task="classification", is_predictable=True), id="binary-predictable-labels"),
-        pytest.param(Config(task="regression", is_predictable=False), id="continuous-random-labels"),
-        pytest.param(Config(task="regression", is_predictable=True), id="continuous-predictable-labels"),
-        pytest.param(Config(task="classification", is_site_confounded=True), id="binary-site-confounded-labels"),
-        pytest.param(Config(task="regression", is_site_confounded=True), id="continuous-site-confounded-labels"),
+        pytest.param(Config(task="classification", signal="random"), id="classification-random"),
+        pytest.param(Config(task="classification", signal="predictable"), id="classification-predictable"),
+        pytest.param(Config(task="classification", signal="site-confounded"), id="classification-site-confounded"),
+        pytest.param(Config(task="regression", signal="random"), id="regression-random"),
+        pytest.param(Config(task="regression", signal="predictable"), id="regression-predictable"),
+        pytest.param(Config(task="regression", signal="site-confounded"), id="regression-site-confounded"),
     ],
 )
 def dataset(request: pytest.FixtureRequest) -> Dataset:
     config: Config = request.param
-
     rng = np.random.default_rng(random_state)
 
+    loadings = rng.normal(size=feature_count)
+
+    connectivity_data: NDArray[np.float32]
     labels: NDArray[np.float64] | NDArray[np.str_]
-    if config.is_site_confounded:
-        # Site drives the features (via ``site_code``) and the labels together,
-        # so the target is recoverable only until the site effect is removed.
-        site_code = np.where(site_labels == "site-a", 1.0, -1.0)
-        loadings = rng.normal(size=feature_count)
-        connectivity_data = (
-            np.outer(site_code, loadings) + rng.normal(scale=0.3, size=(subject_count, feature_count))
-        ).astype(np.float32)
-        match config.task:
-            case "classification":
-                labels = np.where(site_labels == "site-a", "male", "female")
-            case "regression":
-                labels = np.where(site_labels == "site-a", 30.0, 60.0) + rng.normal(scale=2.0, size=subject_count)
+
+    if config.signal == "site-confounded":
+        latent = np.where(site_labels == "site-a", 1.0, -1.0)
     else:
         latent = rng.normal(size=subject_count)
-        loadings = rng.normal(size=feature_count)
-        connectivity_data = (np.outer(latent, loadings) + rng.normal(scale=0.3, size=(subject_count, feature_count))).astype(
-            np.float32
-        )
-        noise = rng.normal(scale=0.5, size=subject_count)
-        match config.task:
-            case "classification":
-                score = latent + noise
-                labels = np.where(score > np.median(score), "male", "female")
-                if not config.is_predictable:
-                    rng.shuffle(labels)
-            case "regression":
-                raw = (latent + noise) if config.is_predictable else (noise + noise)
-                # Rescale to a plausible age range.
-                labels = 18.0 + (raw - raw.min()) / (raw.max() - raw.min()) * 62.0
+    noise = rng.normal(scale=0.5, size=subject_count)
 
+    func: Callable[[NDArray[np.float64]], NDArray[np.float64] | NDArray[np.str_]]
+    match config.task:
+        case "classification":
+            func = sex
+        case "regression":
+            func = age
+
+    match config.signal:
+        case "random":
+            labels = func(rng.normal(size=subject_count))
+        case "predictable":
+            labels = func(latent + noise)
+        case "site-confounded":
+            labels = func(latent)
+
+    noise = rng.normal(scale=0.3, size=(subject_count, feature_count))
+    connectivity_data = (np.outer(latent, loadings) + noise).astype(np.float32)
     return Dataset(
         config=config,
         connectivity_data=connectivity_data,
-        target_labels=labels,
+        labels=labels,
     )
 
 
 @pytest.mark.parametrize(
     "sites",
     [
-        pytest.param(None, id="without-sites"),
-        pytest.param(site_labels, id="with-sites"),
+        pytest.param(None, id="without-site-correction"),
+        pytest.param(site_labels, id="with-site-correction"),
     ],
 )
 def test_training_pipeline(
@@ -115,12 +117,12 @@ def test_training_pipeline(
 
     summary = training_pipeline(
         dataset.connectivity_data,
-        dataset.target_labels,
+        dataset.labels,
         task_type=dataset.config.task,
         n_splits=3,
         n_pca=5,
         n_jobs=1,
-        random_state=42,
+        random_state=random_state,
         sites=sites,
     )
 
@@ -133,7 +135,7 @@ def test_training_pipeline(
 
     score = float(summary.loc[primary_metric, "mean"])  # type: ignore[arg-type]
 
-    if dataset.config.is_site_confounded:
+    if dataset.config.signal == "site-confounded":
         if sites is None:
             # Without correction the site confound is fully exploitable.
             assert score > learnable_threshold
@@ -141,7 +143,7 @@ def test_training_pipeline(
             # Site-effect correction must strip the confound, dropping the
             # otherwise-perfect prediction back to chance level.
             assert score < chance_ceiling
-    elif dataset.config.is_predictable:
+    elif dataset.config.signal == "predictable":
         # Labels that carry signal should be recovered above the chance baseline.
         assert score > learnable_threshold
     else:

--- a/wonkyconn/run.py
+++ b/wonkyconn/run.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Sequence
 
 from . import __version__
-from .config import WonkyConnConfig
+from .config import WonkyconnConfig
 from .logger import logger
 from .workflow import workflow
 
@@ -108,11 +108,11 @@ def _loosen_parser_for_gui(parser: argparse.ArgumentParser) -> None:
             action.required = False
 
 
-def _build_initial_config(args: argparse.Namespace | None) -> WonkyConnConfig:
-    return WonkyConnConfig.from_cli_args(args)
+def _build_initial_config(args: argparse.Namespace | None) -> WonkyconnConfig:
+    return WonkyconnConfig.from_cli_args(args)
 
 
-def _run_textual_ui(config: WonkyConnConfig) -> WonkyConnConfig | None:
+def _run_textual_ui(config: WonkyconnConfig) -> WonkyconnConfig | None:
     if not sys.stdout.isatty():
         print("The Textual UI requires an interactive terminal; run without --textual instead.", file=sys.stderr)
         sys.exit(2)

--- a/wonkyconn/run.py
+++ b/wonkyconn/run.py
@@ -67,6 +67,13 @@ def global_parser(exit_on_error: bool = True) -> argparse.ArgumentParser:
         help="Disable sex and age prediction to reduce runtime.",
     )
     parser.add_argument(
+        "--site_correction",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Apply site correction to the data.",
+    )
+    parser.add_argument(
         "--verbosity",
         help="""
         Verbosity level.

--- a/wonkyconn/run.py
+++ b/wonkyconn/run.py
@@ -67,7 +67,7 @@ def global_parser(exit_on_error: bool = True) -> argparse.ArgumentParser:
         help="Disable sex and age prediction to reduce runtime.",
     )
     parser.add_argument(
-        "--site_correction",
+        "--site-correction",
         required=False,
         action="store_true",
         default=False,

--- a/wonkyconn/tests/test_atlas.py
+++ b/wonkyconn/tests/test_atlas.py
@@ -9,10 +9,7 @@ from templateflow.api import get as get_template
 from wonkyconn.atlas import Atlas
 
 
-def test_dseg_atlas(data_path: Path) -> None:
-    # atlas_path = data_path / YEO_NETWORK_MAP
-    # dl.get(str(atlas_path))
-
+def test_dseg_atlas() -> None:
     url = (
         "https://raw.githubusercontent.com/ThomasYeoLab/CBIG/master/"
         "stable_projects/brain_parcellation/Schaefer2018_LocalGlobal/"
@@ -29,7 +26,7 @@ def test_dseg_atlas(data_path: Path) -> None:
         resolution=2,
         suffix="dseg",
         extension=".nii.gz",
-    )
+    )  # pyright: ignore[reportCallIssue]
     assert isinstance(path, Path)
 
     atlas = Atlas.create("Schaefer2018400Parcels7Networks", path)
@@ -60,10 +57,8 @@ def _get_centroids(path: Path):
     return centroids
 
 
-def test_probseg_atlas(data_path: Path) -> None:
-    # "TODO: @haoting wants to revisit this test, to check if the assertion values make sense"
-    # atlas_path = data_path / YEO_NETWORK_MAP
-    # dl.get(str(atlas_path))
+def test_probseg_atlas() -> None:
+    # TODO: @haoting wants to revisit this test, to check if the assertion values make sense
 
     path = get_template(
         template="MNI152NLin2009cAsym",
@@ -72,7 +67,7 @@ def test_probseg_atlas(data_path: Path) -> None:
         suffix="probseg",
         resolution=3,  # matches “res-03”
         extension=".nii.gz",
-    )
+    )  # pyright: ignore[reportCallIssue]
     assert isinstance(path, Path)
 
     _centroids = _get_centroids(path)

--- a/wonkyconn/tests/test_cli.py
+++ b/wonkyconn/tests/test_cli.py
@@ -130,7 +130,7 @@ def _copy_file(path: Path, new_path: Path, sub: str) -> None:
 @pytest.mark.heavy_smoke
 def test_giga_connectome(data_path: Path, tmp_path: Path):
     data_path = data_path / "giga_connectome" / "connectome_Schaefer20187Networks_dev"
-    dl.get(str(data_path))
+    dl.get(str(data_path))  # pyright: ignore[reportAttributeAccessIssue]
 
     bids_dir = tmp_path / "bids"
     bids_dir.mkdir()
@@ -187,7 +187,7 @@ def test_giga_connectome(data_path: Path, tmp_path: Path):
 @pytest.mark.smoke
 def test_halfpipe(data_path: Path, tmp_path: Path):
     bids_dir = data_path / "halfpipe"
-    dl.get(str(bids_dir))
+    dl.get(str(bids_dir))  # pyright: ignore[reportAttributeAccessIssue]
 
     index = BIDSIndex()
     index.put(bids_dir)
@@ -198,7 +198,7 @@ def test_halfpipe(data_path: Path, tmp_path: Path):
     phenotypes_path = bids_dir / "participants.tsv"
 
     atlas_path = data_path / "atlases"
-    dl.get(str(atlas_path))
+    dl.get(str(atlas_path))  # pyright: ignore[reportAttributeAccessIssue]
 
     atlas_args: list[str] = list()
     atlas_args.append("--atlas")
@@ -237,7 +237,7 @@ def test_halfpipe(data_path: Path, tmp_path: Path):
 @pytest.mark.heavy_smoke
 def test_halfpipe_with_full_metrics(data_path: Path, tmp_path: Path):
     bids_dir = data_path / "halfpipe"
-    dl.get(str(bids_dir))
+    dl.get(str(bids_dir))  # pyright: ignore[reportAttributeAccessIssue]
 
     index = BIDSIndex()
     index.put(bids_dir)
@@ -248,7 +248,7 @@ def test_halfpipe_with_full_metrics(data_path: Path, tmp_path: Path):
     phenotypes_path = bids_dir / "participants.tsv"
 
     atlas_path = data_path / "atlases"
-    dl.get(str(atlas_path))
+    dl.get(str(atlas_path))  # pyright: ignore[reportAttributeAccessIssue]
 
     atlas_args: list[str] = list()
     atlas_args.append("--atlas")

--- a/wonkyconn/tests/test_cli.py
+++ b/wonkyconn/tests/test_cli.py
@@ -85,7 +85,9 @@ def test_cli_and_textual_namespace_consistency(tmp_path: Path):
 
     # Get the attribute names from both namespaces
     cli_attrs = set(vars(cli_args).keys())
+    print(f"CLI attributes: {cli_attrs}")
     config_attrs = set(vars(config_namespace).keys())
+    print(f"Config attributes: {config_attrs}")
 
     # Attributes that are interface-specific and not passed to workflow()
     # These are handled separately before calling workflow()

--- a/wonkyconn/tests/test_cli.py
+++ b/wonkyconn/tests/test_cli.py
@@ -22,7 +22,7 @@ from wonkyconn.run import global_parser, main
 from wonkyconn.workflow import workflow
 
 
-def test_version(capsys):
+def test_version(capsys: pytest.CaptureFixture[str]) -> None:
     try:
         main(["-v"])
     except SystemExit:
@@ -31,7 +31,7 @@ def test_version(capsys):
     assert __version__ == captured.out.split()[0]
 
 
-def test_help(capsys):
+def test_help(capsys: pytest.CaptureFixture[str]) -> None:
     try:
         main(["-h"])
     except SystemExit:
@@ -40,7 +40,7 @@ def test_help(capsys):
     assert "Evaluating the residual motion in fMRI connectome and visualize reports" in captured.out
 
 
-def test_cli_and_textual_namespace_consistency(tmp_path: Path):
+def test_cli_and_textual_namespace_consistency(tmp_path: Path) -> None:
     """Ensure CLI (run.py) and Textual UI produce namespaces with the same attributes.
 
     Both interfaces should produce namespaces that workflow() can consume,
@@ -128,7 +128,7 @@ def _copy_file(path: Path, new_path: Path, sub: str) -> None:
 
 
 @pytest.mark.heavy_smoke
-def test_giga_connectome(data_path: Path, tmp_path: Path):
+def test_giga_connectome(data_path: Path, tmp_path: Path) -> None:
     data_path = data_path / "giga_connectome" / "connectome_Schaefer20187Networks_dev"
     dl.get(str(data_path))  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -185,7 +185,8 @@ def test_giga_connectome(data_path: Path, tmp_path: Path):
 
 
 @pytest.mark.smoke
-def test_halfpipe(data_path: Path, tmp_path: Path):
+@pytest.mark.parametrize("site_correction", [False, True], ids=["no-site-correction", "site-correction"])
+def test_halfpipe(data_path: Path, tmp_path: Path, site_correction: bool) -> None:
     bids_dir = data_path / "halfpipe"
     dl.get(str(bids_dir))  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -216,6 +217,8 @@ def test_halfpipe(data_path: Path, tmp_path: Path):
         str(output_dir),
         "group",
     ]
+    if site_correction:
+        argv.insert(0, "--site-correction")
 
     args = parser.parse_args(argv)
     workflow(args)
@@ -235,7 +238,8 @@ def test_halfpipe(data_path: Path, tmp_path: Path):
 
 
 @pytest.mark.heavy_smoke
-def test_halfpipe_with_full_metrics(data_path: Path, tmp_path: Path):
+@pytest.mark.parametrize("site_correction", [False, True], ids=["no-site-correction", "site-correction"])
+def test_halfpipe_with_full_metrics(data_path: Path, tmp_path: Path, site_correction: bool) -> None:
     bids_dir = data_path / "halfpipe"
     dl.get(str(bids_dir))  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -265,6 +269,8 @@ def test_halfpipe_with_full_metrics(data_path: Path, tmp_path: Path):
         str(output_dir),
         "group",
     ]
+    if site_correction:
+        argv.insert(0, "--site-correction")
 
     args = parser.parse_args(argv)
     workflow(args)

--- a/wonkyconn/tests/test_cli.py
+++ b/wonkyconn/tests/test_cli.py
@@ -85,9 +85,7 @@ def test_cli_and_textual_namespace_consistency(tmp_path: Path):
 
     # Get the attribute names from both namespaces
     cli_attrs = set(vars(cli_args).keys())
-    print(f"CLI attributes: {cli_attrs}")
     config_attrs = set(vars(config_namespace).keys())
-    print(f"Config attributes: {config_attrs}")
 
     # Attributes that are interface-specific and not passed to workflow()
     # These are handled separately before calling workflow()

--- a/wonkyconn/tests/test_cli.py
+++ b/wonkyconn/tests/test_cli.py
@@ -16,7 +16,7 @@ import scipy
 from tqdm.auto import tqdm
 
 from wonkyconn import __version__
-from wonkyconn.config import WonkyConnConfig
+from wonkyconn.config import WonkyconnConfig
 from wonkyconn.file_index.bids import BIDSIndex
 from wonkyconn.run import global_parser, main
 from wonkyconn.workflow import workflow
@@ -72,7 +72,7 @@ def test_cli_and_textual_namespace_consistency(tmp_path: Path) -> None:
     )
 
     # Get namespace from WonkyConnConfig (used by Textual UI)
-    config = WonkyConnConfig(
+    config = WonkyconnConfig(
         bids_dir=bids_dir,
         output_dir=output_dir,
         analysis_level="group",

--- a/wonkyconn/tests/test_correlation.py
+++ b/wonkyconn/tests/test_correlation.py
@@ -15,7 +15,7 @@ def test_correlation() -> None:
     y = np.random.normal(size=(m,))
     cov = np.random.normal(size=(m, 2))
 
-    correlation, count = partial_correlation(x, y, cov)
+    correlation, count = partial_correlation(x, y, cov)  # pyright: ignore[reportCallIssue]
     p_value = correlation_p_value(correlation, count)
 
     assert np.all(np.isfinite(correlation))

--- a/wonkyconn/tests/test_gradients_correlation.py
+++ b/wonkyconn/tests/test_gradients_correlation.py
@@ -36,7 +36,7 @@ def create_fake_connectivity(
     return connectivity_matrices
 
 
-def test_gradients():
+def test_gradients() -> None:
     repo_root = Path(__file__).resolve().parent.parent
 
     path = repo_root / "data" / "gradients"

--- a/wonkyconn/tests/test_gradients_correlation.py
+++ b/wonkyconn/tests/test_gradients_correlation.py
@@ -45,7 +45,8 @@ def test_gradients():
     connectivity_matrices = create_fake_connectivity(n_regions=434, n_subjects=3)
 
     random_gradient, group_gradients = calculate_gradients_correlation.extract_gradients(
-        connectivity_matrices, atlas=nib.load(atlas_file)
+        connectivity_matrices,
+        atlas=nib.nifti1.load(atlas_file),  # pyright: ignore[reportAttributeAccessIssue]
     )
 
     # Calculate similarity for random gradient

--- a/wonkyconn/tests/test_textual_app.py
+++ b/wonkyconn/tests/test_textual_app.py
@@ -1,0 +1,7 @@
+import textual.app
+
+
+def test_import_textual_app() -> None:
+    from wonkyconn import textual_app
+
+    assert issubclass(textual_app.WonkyConnApp, textual.app.App)

--- a/wonkyconn/tests/test_workflow.py
+++ b/wonkyconn/tests/test_workflow.py
@@ -1,0 +1,23 @@
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wonkyconn.workflow import load_data_frame
+
+
+def test_load_data_frame_requires_site_column(tmp_path: Path) -> None:
+    """Enabling site correction requires a 'site' column in the phenotypes file."""
+    phenotypes_path = tmp_path / "participants.tsv"
+    pd.DataFrame(
+        dict(
+            participant_id=["sub-1", "sub-2"],
+            age=[30.0, 40.0],
+            gender=["m", "f"],
+        )
+    ).to_csv(phenotypes_path, sep="\t", index=False)
+
+    args = argparse.Namespace(phenotypes=phenotypes_path, site_correction=True)
+    with pytest.raises(ValueError, match="site"):
+        load_data_frame(args)

--- a/wonkyconn/tests/test_workflow.py
+++ b/wonkyconn/tests/test_workflow.py
@@ -7,17 +7,21 @@ import pytest
 from wonkyconn.workflow import load_data_frame
 
 
-def test_load_data_frame_requires_site_column(tmp_path: Path) -> None:
+@pytest.mark.parametrize("column", ["participant_id", "age", "gender", "site"])
+def test_load_data_frame_missing_column(tmp_path: Path, column: str) -> None:
     """Enabling site correction requires a 'site' column in the phenotypes file."""
+
+    phenotypes = dict(
+        participant_id=["sub-1", "sub-2"],
+        age=[30.0, 40.0],
+        gender=["m", "f"],
+        site=["site-a", "site-b"],
+    )
+    del phenotypes[column]
+
     phenotypes_path = tmp_path / "participants.tsv"
-    pd.DataFrame(
-        dict(
-            participant_id=["sub-1", "sub-2"],
-            age=[30.0, 40.0],
-            gender=["m", "f"],
-        )
-    ).to_csv(phenotypes_path, sep="\t", index=False)
+    pd.DataFrame(phenotypes).to_csv(phenotypes_path, sep="\t", index=False)
 
     args = argparse.Namespace(phenotypes=phenotypes_path, site_correction=True)
-    with pytest.raises(ValueError, match="site"):
+    with pytest.raises(ValueError, match=column):
         load_data_frame(args)

--- a/wonkyconn/textual_app.py
+++ b/wonkyconn/textual_app.py
@@ -21,10 +21,10 @@ from textual.widgets._directory_tree import DirEntry
 from textual.widgets._select import NoSelection
 from textual.widgets._tree import Tree
 
-from .config import WonkyConnConfig
+from .config import WonkyconnConfig
 
 
-class WonkyConnApp(App[WonkyConnConfig | None]):
+class WonkyConnApp(App[WonkyconnConfig | None]):
     """Textual UI for configuring wonkyconn."""
 
     CSS = """
@@ -107,7 +107,7 @@ class WonkyConnApp(App[WonkyConnConfig | None]):
 
     BINDINGS = [("escape", "cancel", "Cancel"), ("ctrl+s", "run", "Run")]
 
-    def __init__(self, initial_config: WonkyConnConfig):
+    def __init__(self, initial_config: WonkyconnConfig):
         super().__init__()
         self.initial_config = initial_config
         self.selected_path: Path | None = None
@@ -301,7 +301,7 @@ class WonkyConnApp(App[WonkyConnConfig | None]):
         if error:
             status.add_class("status-error")
 
-    def _validate_and_build_config(self) -> WonkyConnConfig | None:
+    def _validate_and_build_config(self) -> WonkyconnConfig | None:
         errors: list[str] = list()
 
         bids_str = self._path_values.get("bids_dir", "").strip()
@@ -348,7 +348,7 @@ class WonkyConnApp(App[WonkyConnConfig | None]):
             return None
 
         assert atlas_path is not None  # validated above
-        config = WonkyConnConfig(
+        config = WonkyconnConfig(
             bids_dir=bids_dir,
             output_dir=output_dir,
             analysis_level="group",

--- a/wonkyconn/textual_app.py
+++ b/wonkyconn/textual_app.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
 
-from textual.app import App, ComposeResult  # type: ignore[import-not-found]
-from textual.containers import Center, Container, Horizontal, Vertical  # type: ignore[import-not-found]
-from textual.events import DescendantFocus  # type: ignore[import-not-found]
-from textual.widgets import (  # type: ignore[import-not-found]
+from textual.app import App, ComposeResult
+from textual.containers import Center, Container, Horizontal, Vertical
+from textual.events import DescendantFocus
+from textual.widgets import (
     Button,
     Checkbox,
     DirectoryTree,
@@ -17,9 +17,9 @@ from textual.widgets import (  # type: ignore[import-not-found]
     Select,
     Static,
 )
-from textual.widgets._directory_tree import DirEntry  # type: ignore[import-not-found]
-from textual.widgets._select import NoSelection  # type: ignore[import-not-found]
-from textual.widgets._tree import Tree  # type: ignore[import-not-found]
+from textual.widgets._directory_tree import DirEntry
+from textual.widgets._select import NoSelection
+from textual.widgets._tree import Tree
 
 from .config import WonkyConnConfig
 

--- a/wonkyconn/workflow.py
+++ b/wonkyconn/workflow.py
@@ -140,7 +140,7 @@ def workflow(args: argparse.Namespace) -> None:
             seg_key,
             atlases,
             disable_prediction_gradient,
-            enable_site_correction
+            enable_site_correction,
         )
         record.update(dict(zip(group_by, key, strict=False)))
         if len(group_by) == 2:
@@ -246,7 +246,7 @@ def make_record(
         ages = seg_data_frame["age"].to_numpy()
         genders = seg_data_frame["gender"].to_numpy()
         if site_correction:
-            # Might need to use get_dummies to convert categorical 
+            # Might need to use get_dummies to convert categorical
             # site variable into one-hot encoding for regression
             sites = seg_data_frame["site"].to_numpy()
 

--- a/wonkyconn/workflow.py
+++ b/wonkyconn/workflow.py
@@ -154,7 +154,7 @@ def workflow(args: argparse.Namespace) -> None:
         record["dmn_similarity_mean"] = dmn_similarity_avg
 
         records.append(record)
-    
+
     plot(records, group_by, output_dir)
 
     for record in records:

--- a/wonkyconn/workflow.py
+++ b/wonkyconn/workflow.py
@@ -245,10 +245,6 @@ def make_record(
     try:
         ages = seg_data_frame["age"].to_numpy()
         genders = seg_data_frame["gender"].to_numpy()
-        if site_correction:
-            # Might need to use get_dummies to convert categorical
-            # site variable into one-hot encoding for regression
-            sites = seg_data_frame["site"].to_numpy()
 
         scores = age_sex_scores(
             connectivity_matrices,

--- a/wonkyconn/workflow.py
+++ b/wonkyconn/workflow.py
@@ -56,11 +56,6 @@ def workflow(args: argparse.Namespace) -> None:
         set_verbosity(args.verbosity)
     logger.debug(vars(args))
 
-    # check if light mode is enabled - if so, it will not run the age and sex prediction and gradient similarity
-    disable_prediction_gradient = getattr(args, "light_mode", False)
-
-    enable_site_correction = getattr(args, "site_correction", True)
-
     # Check BIDS path
     bids_dir = args.bids_dir
     index = BIDSIndex()
@@ -139,8 +134,9 @@ def workflow(args: argparse.Namespace) -> None:
             metric_key,
             seg_key,
             atlases,
-            disable_prediction_gradient,
-            enable_site_correction,
+            site_correction=args.site_correction,
+            # check if light mode is enabled - if so, it will not run the age and sex prediction and gradient similarity
+            disable_prediction_gradient=args.light_mode,
         )
         record.update(dict(zip(group_by, key, strict=False)))
         if len(group_by) == 2:
@@ -304,7 +300,7 @@ def load_data_frame(args: argparse.Namespace) -> pd.DataFrame:
         raise ValueError('Phenotypes file is missing the "gender" column')
     if "age" not in data_frame.columns:
         raise ValueError('Phenotypes file is missing the "age" column')
-    if getattr(args, "site_correction", True):
+    if args.site_correction:
         logger.info("Site correction is enabled - checking for 'site' column in phenotypes file.")
         if "site" not in data_frame.columns:
             raise ValueError('Phenotypes file is missing the "site" column required for site correction')

--- a/wonkyconn/workflow.py
+++ b/wonkyconn/workflow.py
@@ -154,7 +154,7 @@ def workflow(args: argparse.Namespace) -> None:
         record["dmn_similarity_mean"] = dmn_similarity_avg
 
         records.append(record)
-
+    
     plot(records, group_by, output_dir)
 
     for record in records:
@@ -245,11 +245,13 @@ def make_record(
     try:
         ages = seg_data_frame["age"].to_numpy()
         genders = seg_data_frame["gender"].to_numpy()
+        sites = seg_data_frame["site"].to_numpy() if site_correction else None
 
         scores = age_sex_scores(
             connectivity_matrices,
             ages=ages,
             genders=genders,
+            sites=sites,
             n_splits=_DEFAULT_N_SPLITS,
             random_state=42,
             n_pca=_DEFAULT_N_PCA,

--- a/wonkyconn/workflow.py
+++ b/wonkyconn/workflow.py
@@ -59,6 +59,8 @@ def workflow(args: argparse.Namespace) -> None:
     # check if light mode is enabled - if so, it will not run the age and sex prediction and gradient similarity
     disable_prediction_gradient = getattr(args, "light_mode", False)
 
+    enable_site_correction = getattr(args, "site_correction", True)
+
     # Check BIDS path
     bids_dir = args.bids_dir
     index = BIDSIndex()
@@ -138,6 +140,7 @@ def workflow(args: argparse.Namespace) -> None:
             seg_key,
             atlases,
             disable_prediction_gradient,
+            enable_site_correction
         )
         record.update(dict(zip(group_by, key, strict=False)))
         if len(group_by) == 2:
@@ -171,6 +174,7 @@ def make_record(
     seg_key: str,
     atlases: dict[str, Atlas],
     disable_prediction_gradient: bool,
+    site_correction: bool = False,
 ) -> dict[str, Any]:
     """Compute all QC metrics for a single group of connectivity matrices."""
     seg_subjects: list[str] = list()
@@ -197,7 +201,7 @@ def make_record(
 
     # Slice phenotypes (age, gender, etc.) for just this group
     seg_data_frame = data_frame.loc[seg_subjects]
-    qcfc = calculate_qcfc(seg_data_frame, connectivity_matrices, metric_key)
+    qcfc = calculate_qcfc(seg_data_frame, connectivity_matrices, metric_key, site_correction)
 
     (seg,) = index.get_tag_values(seg_key, {c.path for c in connectivity_matrices})
     distance_matrix = distance_matrices[seg]
@@ -241,6 +245,10 @@ def make_record(
     try:
         ages = seg_data_frame["age"].to_numpy()
         genders = seg_data_frame["gender"].to_numpy()
+        if site_correction:
+            # Might need to use get_dummies to convert categorical 
+            # site variable into one-hot encoding for regression
+            sites = seg_data_frame["site"].to_numpy()
 
         scores = age_sex_scores(
             connectivity_matrices,
@@ -285,7 +293,9 @@ def make_record(
 
 
 def load_data_frame(args: argparse.Namespace) -> pd.DataFrame:
-    """Load a phenotype TSV with ``participant_id``, ``gender``, and ``age`` columns."""
+    """Load a phenotype TSV with ``participant_id``, ``gender``, and ``age`` columns.
+    If site correction is enabled, the ``site`` column is also required.
+    """
     data_frame = pd.read_csv(
         args.phenotypes,
         sep="\t",
@@ -296,4 +306,8 @@ def load_data_frame(args: argparse.Namespace) -> pd.DataFrame:
         raise ValueError('Phenotypes file is missing the "gender" column')
     if "age" not in data_frame.columns:
         raise ValueError('Phenotypes file is missing the "age" column')
+    if getattr(args, "site_correction", True):
+        logger.info("Site correction is enabled - checking for 'site' column in phenotypes file.")
+        if "site" not in data_frame.columns:
+            raise ValueError('Phenotypes file is missing the "site" column required for site correction')
     return data_frame


### PR DESCRIPTION
Related to #132 

Few changes made so far:
- I added an optional flag to indicate that there are multiple sites in the phenotype file (`--site_correction`, default: False).
- If site correction is enabled, the site column is required to be named "site" and an error is raised otherwise (similar to the checks for the age/gender columns).
- So far, I included site as a covariate for QC-FC metric only (specified using this formula `"age + C(gender) + C(site)"`. We could also use dummy variables if that seems like a cleaner approach—what do you think?

We might need to update our test dataset to have the scanner column named "site" as required.

Todo:

- [x] Update test workflow to run with and without `--site_correction`
- [x] Add site correction in prediction metrics
- [x] Update test dataset phenotype file (with datalad)